### PR TITLE
feat(better-auth-typeorm-adapter): add internal typeorm persistence core

### DIFF
--- a/packages/better-auth/typeorm-adapter/src/lib/internal/create-typeorm-persistence.spec.ts
+++ b/packages/better-auth/typeorm-adapter/src/lib/internal/create-typeorm-persistence.spec.ts
@@ -1,0 +1,829 @@
+import type { CleanedWhere, JoinConfig } from 'better-auth/adapters';
+import type {
+  DataSource,
+  EntityManager,
+  EntityTarget,
+  ObjectLiteral,
+  Repository,
+  SelectQueryBuilder,
+} from 'typeorm';
+
+import { createTypeormPersistence } from './create-typeorm-persistence.js';
+
+type FakeColumn = {
+  propertyName: string;
+  propertyPath: string;
+  databaseName: string;
+  databasePath: string;
+};
+
+type QueryExecution = {
+  one?: ObjectLiteral | null;
+  many?: ObjectLiteral[];
+  count?: number;
+  affected?: number;
+};
+
+class FakeQueryBuilder {
+  readonly whereCalls: Array<{
+    kind: 'where' | 'andWhere' | 'orWhere';
+    expression: string;
+    parameters: Record<string, unknown>;
+  }> = [];
+
+  readonly selects: string[][] = [];
+  readonly orderBys: Array<{ field: string; direction: 'ASC' | 'DESC' }> = [];
+  readonly takes: number[] = [];
+  readonly skips: number[] = [];
+  readonly sets: Record<string, unknown>[] = [];
+  readonly modes: string[] = [];
+  readonly executions: QueryExecution[];
+
+  constructor(executions: QueryExecution[]) {
+    this.executions = [...executions];
+  }
+
+  where(expression: string, parameters: Record<string, unknown> = {}) {
+    this.whereCalls.push({ kind: 'where', expression, parameters });
+    return this;
+  }
+
+  andWhere(expression: string, parameters: Record<string, unknown> = {}) {
+    this.whereCalls.push({ kind: 'andWhere', expression, parameters });
+    return this;
+  }
+
+  orWhere(expression: string, parameters: Record<string, unknown> = {}) {
+    this.whereCalls.push({ kind: 'orWhere', expression, parameters });
+    return this;
+  }
+
+  select(selection: string[]) {
+    this.selects.push(selection);
+    return this;
+  }
+
+  orderBy(field: string, direction: 'ASC' | 'DESC') {
+    this.orderBys.push({ field, direction });
+    return this;
+  }
+
+  take(limit: number) {
+    this.takes.push(limit);
+    return this;
+  }
+
+  skip(offset: number) {
+    this.skips.push(offset);
+    return this;
+  }
+
+  update() {
+    this.modes.push('update');
+    return this;
+  }
+
+  delete() {
+    this.modes.push('delete');
+    return this;
+  }
+
+  set(update: Record<string, unknown>) {
+    this.sets.push(update);
+    return this;
+  }
+
+  async getOne() {
+    return this.executions.shift()?.one ?? null;
+  }
+
+  async getMany() {
+    return this.executions.shift()?.many ?? [];
+  }
+
+  async getCount() {
+    return this.executions.shift()?.count ?? 0;
+  }
+
+  async execute() {
+    const execution = this.executions.shift();
+    return { affected: execution?.affected ?? 0 };
+  }
+}
+
+function createFakeRepository(options: {
+  metadataName: string;
+  columns?: FakeColumn[];
+  primaryColumns?: FakeColumn[];
+  queryExecutions?: QueryExecution[][];
+  saveResult?: ObjectLiteral;
+}) {
+  const columns =
+    options.columns ??
+    [
+      {
+        propertyName: 'id',
+        propertyPath: 'id',
+        databaseName: 'id',
+        databasePath: 'id',
+      },
+      {
+        propertyName: 'email',
+        propertyPath: 'email',
+        databaseName: 'email_address',
+        databasePath: 'email_address',
+      },
+      {
+        propertyName: 'userId',
+        propertyPath: 'userId',
+        databaseName: 'user_id',
+        databasePath: 'user_id',
+      },
+      {
+        propertyName: 'createdAt',
+        propertyPath: 'createdAt',
+        databaseName: 'created_at',
+        databasePath: 'created_at',
+      },
+    ];
+
+  const queryBuilders: FakeQueryBuilder[] = [];
+  const createMock = vi.fn((entity: Record<string, unknown>) => ({ ...entity }));
+  const saveMock = vi.fn(async (entity: ObjectLiteral) => options.saveResult ?? entity);
+  const mergeMock = vi.fn((entity: ObjectLiteral, update: Record<string, unknown>) => ({
+    ...entity,
+    ...update,
+  }));
+  const createQueryBuilderMock = vi.fn(() => {
+    const builder = new FakeQueryBuilder(
+      options.queryExecutions?.shift() ?? [{ many: [] }],
+    );
+    queryBuilders.push(builder);
+    return builder as unknown as SelectQueryBuilder<ObjectLiteral>;
+  });
+
+  const repository = {
+    target: options.metadataName as EntityTarget<ObjectLiteral>,
+    metadata: {
+      name: options.metadataName,
+      columns,
+      primaryColumns:
+        options.primaryColumns ??
+        [
+          {
+            propertyName: 'id',
+            propertyPath: 'id',
+            databaseName: 'id',
+            databasePath: 'id',
+          },
+        ],
+    } as unknown as Repository<ObjectLiteral>['metadata'],
+    create: createMock,
+    save: saveMock,
+    merge: mergeMock,
+    createQueryBuilder: createQueryBuilderMock,
+  };
+
+  return {
+    repository: repository as unknown as Repository<ObjectLiteral>,
+    queryBuilders,
+    metadata: repository.metadata,
+    createMock,
+    saveMock,
+    mergeMock,
+    createQueryBuilderMock,
+  };
+}
+
+function createFakeManager(
+  repositories: Record<string, ReturnType<typeof createFakeRepository>>,
+) {
+  const manager = {
+    getRepository: vi.fn((target: EntityTarget<ObjectLiteral>) => {
+      const repository = repositories[String(target)];
+      if (!repository) {
+        throw new Error(`Unknown repository target ${String(target)}`);
+      }
+      return repository.repository;
+    }),
+    transaction: vi.fn(async (callback: (manager: EntityManager) => Promise<unknown>) =>
+      callback(manager as unknown as EntityManager),
+    ),
+  };
+
+  return manager as unknown as EntityManager & {
+    getRepository: ReturnType<typeof vi.fn>;
+    transaction: ReturnType<typeof vi.fn>;
+  };
+}
+
+function createFakeDataSource(manager: EntityManager) {
+  return {
+    manager,
+    transaction: vi.fn(
+      async (callback: (manager: EntityManager) => Promise<unknown>) =>
+      callback(manager),
+    ),
+  } as unknown as DataSource & {
+    transaction: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('createTypeormPersistence', () => {
+  it('creates records by mapping transformed fields to entity properties', async () => {
+    const userRepository = createFakeRepository({
+      metadataName: 'UserEntity',
+      saveResult: {
+        id: 'user_1',
+        email: 'alice@example.com',
+      },
+    });
+    const manager = createFakeManager({ UserEntity: userRepository });
+    const dataSource = createFakeDataSource(manager);
+    const persistence = createTypeormPersistence({
+      dataSource,
+      manager,
+      models: { user: 'UserEntity' },
+    });
+
+    const created = await persistence.create({
+      model: 'user',
+      data: {
+        id: 'user_1',
+        email_address: 'alice@example.com',
+      },
+      select: ['id', 'email_address'],
+    });
+
+    expect(userRepository.createMock).toHaveBeenCalledWith({
+      id: 'user_1',
+      email: 'alice@example.com',
+    });
+    expect(created).toEqual({
+      id: 'user_1',
+      email_address: 'alice@example.com',
+    });
+  });
+
+  it('resolves fields by property or database column name and applies sort and pagination', async () => {
+    const userRepository = createFakeRepository({
+      metadataName: 'UserEntity',
+      queryExecutions: [[{ many: [{ id: 'user_1', email: 'alice@example.com' }] }]],
+    });
+    const manager = createFakeManager({ UserEntity: userRepository });
+    const dataSource = createFakeDataSource(manager);
+    const persistence = createTypeormPersistence({
+      dataSource,
+      manager,
+      models: { user: 'UserEntity' },
+    });
+
+    const records = await persistence.findMany({
+      model: 'user',
+      where: [
+        {
+          field: 'email_address',
+          operator: 'eq',
+          value: 'alice@example.com',
+          connector: 'AND',
+        },
+      ],
+      limit: 10,
+      offset: 5,
+      sortBy: {
+        field: 'email',
+        direction: 'desc',
+      },
+      select: ['id', 'email_address'],
+    });
+
+    expect(records).toEqual([
+      {
+        id: 'user_1',
+        email_address: 'alice@example.com',
+      },
+    ]);
+    expect(userRepository.queryBuilders[0]?.whereCalls[0]?.expression).toContain(
+      'entity.email =',
+    );
+    expect(userRepository.queryBuilders[0]?.orderBys).toEqual([
+      { field: 'entity.email', direction: 'DESC' },
+    ]);
+    expect(userRepository.queryBuilders[0]?.takes).toEqual([10]);
+    expect(userRepository.queryBuilders[0]?.skips).toEqual([5]);
+  });
+
+  it('throws explicit errors for missing models and unresolved fields', async () => {
+    const manager = createFakeManager({});
+    const dataSource = createFakeDataSource(manager);
+    const persistence = createTypeormPersistence({
+      dataSource,
+      manager,
+      models: {},
+    });
+
+    await expect(
+      persistence.findMany({
+        model: 'user',
+        limit: 10,
+      }),
+    ).rejects.toThrow('No TypeORM entity mapping was registered');
+
+    const userRepository = createFakeRepository({
+      metadataName: 'UserEntity',
+    });
+    const managerWithRepository = createFakeManager({ UserEntity: userRepository });
+    const persistenceWithRepository = createTypeormPersistence({
+      dataSource: createFakeDataSource(managerWithRepository),
+      manager: managerWithRepository,
+      models: { user: 'UserEntity' },
+    });
+
+    await expect(
+      persistenceWithRepository.findMany({
+        model: 'user',
+        limit: 10,
+        where: [
+          {
+            field: 'missing_field',
+            operator: 'eq',
+            value: 'x',
+            connector: 'AND',
+          },
+        ],
+      }),
+    ).rejects.toThrow('Could not resolve field "missing_field"');
+  });
+
+  it('applies every supported where operator and preserves connector order', async () => {
+    const userRepository = createFakeRepository({
+      metadataName: 'UserEntity',
+      queryExecutions: [[{ many: [] }]],
+    });
+    const manager = createFakeManager({ UserEntity: userRepository });
+    const dataSource = createFakeDataSource(manager);
+    const persistence = createTypeormPersistence({
+      dataSource,
+      manager,
+      models: { user: 'UserEntity' },
+    });
+
+    const where: CleanedWhere[] = [
+      { field: 'email_address', operator: 'eq', value: 'alice', connector: 'AND' },
+      { field: 'email_address', operator: 'ne', value: 'bob', connector: 'OR' },
+      { field: 'id', operator: 'lt', value: 10, connector: 'AND' },
+      { field: 'id', operator: 'lte', value: 11, connector: 'AND' },
+      { field: 'id', operator: 'gt', value: 12, connector: 'AND' },
+      { field: 'id', operator: 'gte', value: 13, connector: 'AND' },
+      {
+        field: 'email_address',
+        operator: 'in',
+        value: ['alice', null, 'bob'] as unknown as CleanedWhere['value'],
+        connector: 'AND',
+      },
+      {
+        field: 'email_address',
+        operator: 'not_in',
+        value: ['carol', null, 'dave'] as unknown as CleanedWhere['value'],
+        connector: 'AND',
+      },
+      {
+        field: 'email_address',
+        operator: 'contains',
+        value: 'example',
+        connector: 'AND',
+      },
+      {
+        field: 'email_address',
+        operator: 'starts_with',
+        value: 'alice',
+        connector: 'AND',
+      },
+      {
+        field: 'email_address',
+        operator: 'ends_with',
+        value: '.com',
+        connector: 'AND',
+      },
+      { field: 'created_at', operator: 'eq', value: null, connector: 'AND' },
+      { field: 'created_at', operator: 'ne', value: null, connector: 'AND' },
+    ];
+
+    await persistence.findMany({
+      model: 'user',
+      where,
+      limit: 25,
+    });
+
+    const expressions = userRepository.queryBuilders[0]?.whereCalls.map(
+      (call) => `${call.kind}:${call.expression}`,
+    );
+
+    expect(expressions).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('where:entity.email ='),
+        expect.stringContaining('orWhere:entity.email !='),
+        expect.stringContaining('andWhere:entity.id <'),
+        expect.stringContaining('andWhere:entity.id <='),
+        expect.stringContaining('andWhere:entity.id >'),
+        expect.stringContaining('andWhere:entity.id >='),
+        expect.stringContaining('andWhere:(entity.email IN'),
+        expect.stringContaining('andWhere:(entity.email NOT IN'),
+        expect.stringContaining('andWhere:entity.email LIKE'),
+        expect.stringContaining('andWhere:entity.createdAt IS NULL'),
+        expect.stringContaining('andWhere:entity.createdAt IS NOT NULL'),
+      ]),
+    );
+  });
+
+  it('handles empty in and not_in semantics explicitly', async () => {
+    const userRepository = createFakeRepository({
+      metadataName: 'UserEntity',
+      queryExecutions: [[{ many: [] }], [{ many: [] }]],
+    });
+    const manager = createFakeManager({ UserEntity: userRepository });
+    const dataSource = createFakeDataSource(manager);
+    const persistence = createTypeormPersistence({
+      dataSource,
+      manager,
+      models: { user: 'UserEntity' },
+    });
+
+    await persistence.findMany({
+      model: 'user',
+      where: [
+        { field: 'id', operator: 'in', value: [], connector: 'AND' },
+      ],
+      limit: 5,
+    });
+
+    await persistence.findMany({
+      model: 'user',
+      where: [
+        { field: 'id', operator: 'not_in', value: [], connector: 'AND' },
+      ],
+      limit: 5,
+    });
+
+    expect(userRepository.queryBuilders[0]?.whereCalls[0]?.expression).toBe('1 = 0');
+    expect(userRepository.queryBuilders[1]?.whereCalls[0]?.expression).toBe('1 = 1');
+  });
+
+  it('updates deterministically by reading, saving, and rereading the entity', async () => {
+    const userRepository = createFakeRepository({
+      metadataName: 'UserEntity',
+      queryExecutions: [
+        [{ one: { id: 'user_1', email: 'alice@example.com' } }],
+        [{ one: { id: 'user_1', email: 'updated@example.com' } }],
+      ],
+    });
+    const manager = createFakeManager({ UserEntity: userRepository });
+    const dataSource = createFakeDataSource(manager);
+    const persistence = createTypeormPersistence({
+      dataSource,
+      manager,
+      models: { user: 'UserEntity' },
+    });
+
+    const updated = await persistence.update({
+      model: 'user',
+      where: [
+        {
+          field: 'id',
+          operator: 'eq',
+          value: 'user_1',
+          connector: 'AND',
+        },
+      ],
+      update: {
+        email_address: 'updated@example.com',
+      },
+    });
+
+    expect(userRepository.saveMock).toHaveBeenCalledWith({
+      id: 'user_1',
+      email: 'updated@example.com',
+    });
+    expect(updated).toEqual({
+      id: 'user_1',
+      email_address: 'updated@example.com',
+    });
+  });
+
+  it('throws for unsupported primary-key situations during deterministic updates', async () => {
+    const userRepository = createFakeRepository({
+      metadataName: 'UserEntity',
+      primaryColumns: [
+        {
+          propertyName: 'id',
+          propertyPath: 'id',
+          databaseName: 'id',
+          databasePath: 'id',
+        },
+        {
+          propertyName: 'tenantId',
+          propertyPath: 'tenantId',
+          databaseName: 'tenant_id',
+          databasePath: 'tenant_id',
+        },
+      ],
+      queryExecutions: [[{ one: { id: 'user_1', tenantId: 'tenant_1' } }]],
+    });
+    const manager = createFakeManager({ UserEntity: userRepository });
+    const persistence = createTypeormPersistence({
+      dataSource: createFakeDataSource(manager),
+      manager,
+      models: { user: 'UserEntity' },
+    });
+
+    await expect(
+      persistence.update({
+        model: 'user',
+        where: [
+          {
+            field: 'id',
+            operator: 'eq',
+            value: 'user_1',
+            connector: 'AND',
+          },
+        ],
+        update: {
+          email_address: 'updated@example.com',
+        },
+      }),
+    ).rejects.toThrow(
+      'Better Auth TypeORM persistence currently requires a single primary column',
+    );
+  });
+
+  it('returns counts and affected rows for bulk operations', async () => {
+    const userRepository = createFakeRepository({
+      metadataName: 'UserEntity',
+      queryExecutions: [[{ count: 7 }], [{ affected: 3 }], [{ affected: 2 }], [{ affected: 1 }]],
+    });
+    const manager = createFakeManager({ UserEntity: userRepository });
+    const dataSource = createFakeDataSource(manager);
+    const persistence = createTypeormPersistence({
+      dataSource,
+      manager,
+      models: { user: 'UserEntity' },
+    });
+
+    expect(
+      await persistence.count({
+        model: 'user',
+        where: [
+          {
+            field: 'email_address',
+            operator: 'contains',
+            value: 'example',
+            connector: 'AND',
+          },
+        ],
+      }),
+    ).toBe(7);
+
+    expect(
+      await persistence.updateMany({
+        model: 'user',
+        where: [
+          {
+            field: 'email_address',
+            operator: 'contains',
+            value: 'example',
+            connector: 'AND',
+          },
+        ],
+        update: {
+          email_address: 'bulk@example.com',
+        },
+      }),
+    ).toBe(3);
+
+    expect(
+      await persistence.deleteMany({
+        model: 'user',
+        where: [
+          {
+            field: 'email_address',
+            operator: 'contains',
+            value: 'example',
+            connector: 'AND',
+          },
+        ],
+      }),
+    ).toBe(2);
+
+    await expect(
+      persistence.delete({
+        model: 'user',
+        where: [
+          {
+            field: 'id',
+            operator: 'eq',
+            value: 'user_1',
+            connector: 'AND',
+          },
+        ],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('hydrates one-to-one, one-to-many, and many-to-many joins', async () => {
+    const userRepository = createFakeRepository({
+      metadataName: 'UserEntity',
+      queryExecutions: [[{ many: [{ id: 'user_1' }, { id: 'user_2' }] }]],
+    });
+    const sessionRepository = createFakeRepository({
+      metadataName: 'SessionEntity',
+      columns: [
+        {
+          propertyName: 'id',
+          propertyPath: 'id',
+          databaseName: 'id',
+          databasePath: 'id',
+        },
+        {
+          propertyName: 'userId',
+          propertyPath: 'userId',
+          databaseName: 'user_id',
+          databasePath: 'user_id',
+        },
+      ],
+      queryExecutions: [
+        [{ one: { id: 'session_1', userId: 'user_1' } }],
+        [{ one: null }],
+      ],
+    });
+    const accountRepository = createFakeRepository({
+      metadataName: 'AccountEntity',
+      columns: [
+        {
+          propertyName: 'id',
+          propertyPath: 'id',
+          databaseName: 'id',
+          databasePath: 'id',
+        },
+        {
+          propertyName: 'userId',
+          propertyPath: 'userId',
+          databaseName: 'user_id',
+          databasePath: 'user_id',
+        },
+      ],
+      queryExecutions: [
+        [{ many: [{ id: 'account_1', userId: 'user_1' }] }],
+        [{ many: [] }],
+      ],
+    });
+    const passkeyRepository = createFakeRepository({
+      metadataName: 'PasskeyEntity',
+      columns: [
+        {
+          propertyName: 'id',
+          propertyPath: 'id',
+          databaseName: 'id',
+          databasePath: 'id',
+        },
+        {
+          propertyName: 'userId',
+          propertyPath: 'userId',
+          databaseName: 'user_id',
+          databasePath: 'user_id',
+        },
+      ],
+      queryExecutions: [
+        [{ many: [{ id: 'passkey_1', userId: 'user_1' }] }],
+        [{ many: [] }],
+      ],
+    });
+
+    const manager = createFakeManager({
+      UserEntity: userRepository,
+      SessionEntity: sessionRepository,
+      AccountEntity: accountRepository,
+      PasskeyEntity: passkeyRepository,
+    });
+    const persistence = createTypeormPersistence({
+      dataSource: createFakeDataSource(manager),
+      manager,
+      models: {
+        user: 'UserEntity',
+        session: 'SessionEntity',
+        account: 'AccountEntity',
+        passkey: 'PasskeyEntity',
+      },
+    });
+
+    const records = await persistence.findMany<Record<string, unknown>>({
+      model: 'user',
+      limit: 10,
+      join: {
+        session: {
+          on: { from: 'id', to: 'user_id' },
+          relation: 'one-to-one',
+        },
+        account: {
+          on: { from: 'id', to: 'user_id' },
+          relation: 'one-to-many',
+          limit: 1,
+        },
+        passkey: {
+          on: { from: 'id', to: 'user_id' },
+          relation: 'many-to-many',
+          limit: 1,
+        },
+      } satisfies JoinConfig,
+    });
+
+    expect(records).toEqual([
+      {
+        id: 'user_1',
+        session: { id: 'session_1', user_id: 'user_1' },
+        account: [{ id: 'account_1', user_id: 'user_1' }],
+        passkey: [{ id: 'passkey_1', user_id: 'user_1' }],
+      },
+      {
+        id: 'user_2',
+        session: null,
+        account: [],
+        passkey: [],
+      },
+    ]);
+  });
+
+  it('short-circuits joins when the base record has no join key', async () => {
+    const userRepository = createFakeRepository({
+      metadataName: 'UserEntity',
+      queryExecutions: [[{ many: [{ id: null }] }]],
+    });
+    const sessionRepository = createFakeRepository({
+      metadataName: 'SessionEntity',
+      queryExecutions: [],
+    });
+    const manager = createFakeManager({
+      UserEntity: userRepository,
+      SessionEntity: sessionRepository,
+    });
+    const persistence = createTypeormPersistence({
+      dataSource: createFakeDataSource(manager),
+      manager,
+      models: { user: 'UserEntity', session: 'SessionEntity' },
+    });
+
+    const records = await persistence.findMany<Record<string, unknown>>({
+      model: 'user',
+      limit: 10,
+      join: {
+        session: {
+          on: { from: 'id', to: 'user_id' },
+          relation: 'one-to-many',
+        },
+      },
+    });
+
+    expect(records).toEqual([{ id: null, session: [] }]);
+    expect(sessionRepository.queryBuilders).toHaveLength(0);
+  });
+
+  it('uses the root data source transaction and returns manager-scoped persistence', async () => {
+    const userRepository = createFakeRepository({
+      metadataName: 'UserEntity',
+      queryExecutions: [[{ many: [] }]],
+    });
+    const manager = createFakeManager({ UserEntity: userRepository });
+    const dataSource = createFakeDataSource(manager);
+    const persistence = createTypeormPersistence({
+      dataSource,
+      models: { user: 'UserEntity' },
+    });
+
+    await persistence.transaction(async (transactionPersistence) => {
+      await transactionPersistence.findMany({
+        model: 'user',
+        limit: 5,
+      });
+      return null;
+    });
+
+    expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+    expect(manager.getRepository).toHaveBeenCalled();
+  });
+
+  it('delegates nested transactions to the provided manager', async () => {
+    const userRepository = createFakeRepository({
+      metadataName: 'UserEntity',
+      queryExecutions: [],
+    });
+    const manager = createFakeManager({ UserEntity: userRepository });
+    const persistence = createTypeormPersistence({
+      dataSource: createFakeDataSource(manager),
+      manager,
+      models: { user: 'UserEntity' },
+    });
+
+    await persistence.transaction(async () => null);
+
+    expect(manager.transaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/better-auth/typeorm-adapter/src/lib/internal/create-typeorm-persistence.ts
+++ b/packages/better-auth/typeorm-adapter/src/lib/internal/create-typeorm-persistence.ts
@@ -1,0 +1,406 @@
+import type {
+  CleanedWhere,
+  CustomAdapter,
+  JoinConfig,
+} from 'better-auth/adapters';
+import type {
+  DataSource,
+  EntityManager,
+  ObjectLiteral,
+  Repository,
+} from 'typeorm';
+
+import type { BetterAuthTypeormModelMap } from '../types.js';
+import {
+  mapEntityRecordToOutput,
+  mapEntityRecordsToOutput,
+  mapInputRecordToEntityProperties,
+  mapUpdateRecordToEntityProperties,
+  resolveSelectFields,
+} from './field-mapping.js';
+import {
+  getSinglePrimaryField,
+  resolveModelRepository,
+} from './metadata.js';
+import {
+  applySortAndPagination,
+  applyWhereClauses,
+  createRepositoryQueryBuilder,
+} from './query-builder.js';
+
+const DEFAULT_JOIN_LIMIT = 100;
+type PersistenceWhereValue = CleanedWhere['value'];
+
+export interface BetterAuthTypeormPersistence extends CustomAdapter {
+  transaction: <R>(
+    callback: (trx: BetterAuthTypeormPersistence) => Promise<R>,
+  ) => Promise<R>;
+}
+
+export interface CreateTypeormPersistenceOptions {
+  dataSource: DataSource;
+  models: BetterAuthTypeormModelMap;
+  manager?: EntityManager;
+}
+
+function createPersistenceScope(options: CreateTypeormPersistenceOptions) {
+  return {
+    dataSource: options.dataSource,
+    manager: options.manager ?? options.dataSource.manager,
+    models: options.models,
+  };
+}
+
+function isPersistenceWhereValue(value: unknown): value is PersistenceWhereValue {
+  return (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value instanceof Date
+  );
+}
+
+async function hydrateJoinForRecord(
+  persistence: BetterAuthTypeormPersistence,
+  baseRecord: Record<string, unknown>,
+  joinModel: string,
+  joinConfig: JoinConfig[string],
+): Promise<unknown> {
+  const joinKey = baseRecord[joinConfig.on.from];
+
+  if (typeof joinKey === 'undefined' || joinKey === null) {
+    return joinConfig.relation === 'one-to-one' ? null : [];
+  }
+
+  if (!isPersistenceWhereValue(joinKey)) {
+    return joinConfig.relation === 'one-to-one' ? null : [];
+  }
+
+  if (joinConfig.relation === 'one-to-one') {
+    return persistence.findOne<Record<string, unknown>>({
+      model: joinModel,
+      where: [
+        {
+          field: joinConfig.on.to,
+          operator: 'eq',
+          value: joinKey,
+          connector: 'AND',
+        },
+      ],
+    });
+  }
+
+  return persistence.findMany<Record<string, unknown>>({
+    model: joinModel,
+    where: [
+      {
+        field: joinConfig.on.to,
+        operator: 'eq',
+        value: joinKey,
+        connector: 'AND',
+      },
+    ],
+    limit: joinConfig.limit ?? DEFAULT_JOIN_LIMIT,
+  });
+}
+
+async function attachJoinResults(
+  persistence: BetterAuthTypeormPersistence,
+  records: Record<string, unknown>[],
+  join: JoinConfig | undefined,
+): Promise<Record<string, unknown>[]> {
+  if (!join || records.length === 0) {
+    return records;
+  }
+
+  const hydratedRecords = [...records];
+
+  for (const [joinModel, joinConfig] of Object.entries(join)) {
+    for (const record of hydratedRecords) {
+      record[joinModel] = await hydrateJoinForRecord(
+        persistence,
+        record,
+        joinModel,
+        joinConfig,
+      );
+    }
+  }
+
+  return hydratedRecords;
+}
+
+function applySelect(
+  queryBuilder: ReturnType<typeof createRepositoryQueryBuilder>,
+  repository: Repository<ObjectLiteral>,
+  select: string[] | undefined,
+): void {
+  if (!select || select.length === 0) {
+    return;
+  }
+
+  const selection = resolveSelectFields(
+    {
+      model: repository.metadata.name,
+      repository,
+      target: repository.target,
+      metadata: repository.metadata,
+    },
+    select,
+  ).map((field) => `entity.${field.propertyPath}`);
+
+  if (selection.length > 0) {
+    queryBuilder.select(selection);
+  }
+}
+
+export function createTypeormPersistence(
+  options: CreateTypeormPersistenceOptions,
+): BetterAuthTypeormPersistence {
+  const scope = createPersistenceScope(options);
+
+  const persistence: BetterAuthTypeormPersistence = {
+    async create<T extends Record<string, unknown>>({
+      model,
+      data,
+      select,
+    }: {
+      model: string;
+      data: T;
+      select?: string[] | undefined;
+    }): Promise<T> {
+      const repositoryContext = resolveModelRepository(scope, model);
+      const entityData = mapInputRecordToEntityProperties(repositoryContext, data);
+      const entity = repositoryContext.repository.create(entityData);
+      const savedEntity = await repositoryContext.repository.save(entity);
+
+      return mapEntityRecordToOutput(
+        repositoryContext,
+        savedEntity,
+        select,
+      ) as T;
+    },
+
+    async findOne<T>({
+      model,
+      where,
+      select,
+      join,
+    }: {
+      model: string;
+      where: CleanedWhere[];
+      select?: string[] | undefined;
+      join?: JoinConfig | undefined;
+    }): Promise<T | null> {
+      const repositoryContext = resolveModelRepository(scope, model);
+      const queryBuilder = createRepositoryQueryBuilder(repositoryContext);
+
+      applySelect(queryBuilder, repositoryContext.repository, select);
+      applyWhereClauses(queryBuilder, repositoryContext, where);
+
+      const entity = await queryBuilder.getOne();
+
+      if (!entity) {
+        return null;
+      }
+
+      const [hydratedRecord] = await attachJoinResults(
+        persistence,
+        [mapEntityRecordToOutput(repositoryContext, entity, select)],
+        join,
+      );
+
+      return hydratedRecord as T;
+    },
+
+    async findMany<T>({
+      model,
+      where,
+      limit,
+      select,
+      sortBy,
+      offset,
+      join,
+    }: {
+      model: string;
+      where?: CleanedWhere[] | undefined;
+      limit: number;
+      select?: string[] | undefined;
+      sortBy?: { field: string; direction: 'asc' | 'desc' } | undefined;
+      offset?: number | undefined;
+      join?: JoinConfig | undefined;
+    }): Promise<T[]> {
+      const repositoryContext = resolveModelRepository(scope, model);
+      const queryBuilder = createRepositoryQueryBuilder(repositoryContext);
+
+      applySelect(queryBuilder, repositoryContext.repository, select);
+      applyWhereClauses(queryBuilder, repositoryContext, where);
+      applySortAndPagination(queryBuilder, repositoryContext, {
+        sortBy,
+        limit,
+        offset,
+      });
+
+      const entities = await queryBuilder.getMany();
+      const records = mapEntityRecordsToOutput(repositoryContext, entities, select);
+
+      return (await attachJoinResults(persistence, records, join)) as T[];
+    },
+
+    async count({
+      model,
+      where,
+    }: {
+      model: string;
+      where?: CleanedWhere[] | undefined;
+    }): Promise<number> {
+      const repositoryContext = resolveModelRepository(scope, model);
+      const queryBuilder = createRepositoryQueryBuilder(repositoryContext);
+
+      applyWhereClauses(queryBuilder, repositoryContext, where);
+
+      return queryBuilder.getCount();
+    },
+
+    async update<T>({
+      model,
+      where,
+      update,
+    }: {
+      model: string;
+      where: CleanedWhere[];
+      update: T;
+    }): Promise<T | null> {
+      const repositoryContext = resolveModelRepository(scope, model);
+      const queryBuilder = createRepositoryQueryBuilder(repositoryContext);
+
+      applyWhereClauses(queryBuilder, repositoryContext, where);
+
+      const existingEntity = await queryBuilder.getOne();
+
+      if (!existingEntity) {
+        return null;
+      }
+
+      const primaryField = getSinglePrimaryField(repositoryContext);
+      const mappedUpdate = mapUpdateRecordToEntityProperties(
+        repositoryContext,
+        update as Record<string, unknown>,
+      );
+      const mergedEntity = repositoryContext.repository.merge(
+        existingEntity,
+        mappedUpdate,
+      );
+
+      await repositoryContext.repository.save(mergedEntity);
+
+      const rereadQueryBuilder = createRepositoryQueryBuilder(repositoryContext);
+      const primaryValue = existingEntity[primaryField.propertyName];
+
+      applyWhereClauses(
+        rereadQueryBuilder,
+        repositoryContext,
+        [
+          {
+            field: primaryField.databaseName,
+            operator: 'eq',
+            value: primaryValue,
+            connector: 'AND',
+          },
+        ],
+      );
+
+      const rereadEntity = await rereadQueryBuilder.getOne();
+
+      if (!rereadEntity) {
+        return null;
+      }
+
+      return mapEntityRecordToOutput(repositoryContext, rereadEntity) as T;
+    },
+
+    async updateMany({
+      model,
+      where,
+      update,
+    }: {
+      model: string;
+      where: CleanedWhere[];
+      update: Record<string, unknown>;
+    }): Promise<number> {
+      const repositoryContext = resolveModelRepository(scope, model);
+      const queryBuilder = createRepositoryQueryBuilder(repositoryContext);
+      const mappedUpdate = mapUpdateRecordToEntityProperties(repositoryContext, update);
+
+      queryBuilder.update().set(mappedUpdate);
+      applyWhereClauses(queryBuilder, repositoryContext, where);
+
+      const result = await queryBuilder.execute();
+
+      return result.affected ?? 0;
+    },
+
+    async delete({
+      model,
+      where,
+    }: {
+      model: string;
+      where: CleanedWhere[];
+    }): Promise<void> {
+      const repositoryContext = resolveModelRepository(scope, model);
+      const queryBuilder = createRepositoryQueryBuilder(repositoryContext);
+
+      queryBuilder.delete();
+      applyWhereClauses(queryBuilder, repositoryContext, where);
+      await queryBuilder.execute();
+    },
+
+    async deleteMany({
+      model,
+      where,
+    }: {
+      model: string;
+      where: CleanedWhere[];
+    }): Promise<number> {
+      const repositoryContext = resolveModelRepository(scope, model);
+      const queryBuilder = createRepositoryQueryBuilder(repositoryContext);
+
+      queryBuilder.delete();
+      applyWhereClauses(queryBuilder, repositoryContext, where);
+
+      const result = await queryBuilder.execute();
+
+      return result.affected ?? 0;
+    },
+
+    async transaction<R>(
+      callback: (trx: BetterAuthTypeormPersistence) => Promise<R>,
+    ): Promise<R> {
+      if (options.manager) {
+        return scope.manager.transaction(async (transactionManager) =>
+          callback(
+            createTypeormPersistence({
+              dataSource: options.dataSource,
+              models: options.models,
+              manager: transactionManager,
+            }),
+          ),
+        );
+      }
+
+      return options.dataSource.transaction(async (transactionManager) =>
+        callback(
+          createTypeormPersistence({
+            dataSource: options.dataSource,
+            models: options.models,
+            manager: transactionManager,
+          }),
+        ),
+      );
+    },
+
+    options: undefined,
+  };
+
+  return persistence;
+}

--- a/packages/better-auth/typeorm-adapter/src/lib/internal/errors.ts
+++ b/packages/better-auth/typeorm-adapter/src/lib/internal/errors.ts
@@ -1,0 +1,27 @@
+export class BetterAuthTypeormPersistenceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BetterAuthTypeormPersistenceError';
+  }
+}
+
+export function createMissingModelMappingError(model: string): Error {
+  return new BetterAuthTypeormPersistenceError(
+    `No TypeORM entity mapping was registered for Better Auth model "${model}".`,
+  );
+}
+
+export function createUnresolvedFieldError(
+  model: string,
+  field: string,
+): Error {
+  return new BetterAuthTypeormPersistenceError(
+    `Could not resolve field "${field}" for Better Auth model "${model}".`,
+  );
+}
+
+export function createUnsupportedPrimaryKeyError(model: string): Error {
+  return new BetterAuthTypeormPersistenceError(
+    `Better Auth TypeORM persistence currently requires a single primary column for model "${model}".`,
+  );
+}

--- a/packages/better-auth/typeorm-adapter/src/lib/internal/field-mapping.ts
+++ b/packages/better-auth/typeorm-adapter/src/lib/internal/field-mapping.ts
@@ -1,0 +1,81 @@
+import type { ObjectLiteral } from 'typeorm';
+
+import type { ModelRepositoryContext, ResolvedField } from './metadata.js';
+import { resolveField } from './metadata.js';
+
+function pickSelectedFields(
+  mappedRecord: Record<string, unknown>,
+  select: string[] | undefined,
+): Record<string, unknown> {
+  if (!select || select.length === 0) {
+    return mappedRecord;
+  }
+
+  const selectedRecord: Record<string, unknown> = {};
+
+  for (const key of select) {
+    if (Object.hasOwn(mappedRecord, key)) {
+      selectedRecord[key] = mappedRecord[key];
+    }
+  }
+
+  return selectedRecord;
+}
+
+export function mapInputRecordToEntityProperties(
+  repositoryContext: ModelRepositoryContext,
+  input: Record<string, unknown>,
+): Record<string, unknown> {
+  const mappedInput: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(input)) {
+    const field = resolveField(repositoryContext, key);
+    mappedInput[field.propertyName] = value;
+  }
+
+  return mappedInput;
+}
+
+export function mapUpdateRecordToEntityProperties(
+  repositoryContext: ModelRepositoryContext,
+  update: Record<string, unknown>,
+): Record<string, unknown> {
+  return mapInputRecordToEntityProperties(repositoryContext, update);
+}
+
+export function mapEntityRecordToOutput(
+  repositoryContext: ModelRepositoryContext,
+  row: ObjectLiteral,
+  select?: string[] | undefined,
+): Record<string, unknown> {
+  const mappedRecord: Record<string, unknown> = {};
+
+  for (const column of repositoryContext.metadata.columns) {
+    if (typeof row[column.propertyName] === 'undefined') {
+      continue;
+    }
+
+    mappedRecord[column.databaseName] = row[column.propertyName];
+  }
+
+  return pickSelectedFields(mappedRecord, select);
+}
+
+export function mapEntityRecordsToOutput(
+  repositoryContext: ModelRepositoryContext,
+  rows: ObjectLiteral[],
+  select?: string[] | undefined,
+): Record<string, unknown>[] {
+  return rows.map((row) => mapEntityRecordToOutput(repositoryContext, row, select));
+}
+
+export function resolveSelectFields(
+  repositoryContext: ModelRepositoryContext,
+  select?: string[] | undefined,
+): ResolvedField[] {
+  if (!select || select.length === 0) {
+    return [];
+  }
+
+  return select.map((field) => resolveField(repositoryContext, field));
+}

--- a/packages/better-auth/typeorm-adapter/src/lib/internal/metadata.ts
+++ b/packages/better-auth/typeorm-adapter/src/lib/internal/metadata.ts
@@ -1,0 +1,95 @@
+import type { EntityManager, EntityTarget, ObjectLiteral, Repository } from 'typeorm';
+
+import type { BetterAuthTypeormModelMap } from '../types.js';
+import {
+  createMissingModelMappingError,
+  createUnresolvedFieldError,
+  createUnsupportedPrimaryKeyError,
+} from './errors.js';
+
+type EntityMetadata = Repository<ObjectLiteral>['metadata'];
+type EntityColumn = EntityMetadata['columns'][number];
+
+export interface PersistenceContext {
+  readonly manager: EntityManager;
+  readonly models: BetterAuthTypeormModelMap;
+}
+
+export interface ModelRepositoryContext {
+  readonly model: string;
+  readonly target: EntityTarget<ObjectLiteral>;
+  readonly repository: Repository<ObjectLiteral>;
+  readonly metadata: EntityMetadata;
+}
+
+export interface ResolvedField {
+  readonly inputName: string;
+  readonly propertyName: string;
+  readonly propertyPath: string;
+  readonly databaseName: string;
+}
+
+function findColumn(metadata: EntityMetadata, field: string): EntityColumn | null {
+  return (
+    metadata.columns.find((column) => column.propertyName === field) ??
+    metadata.columns.find((column) => column.propertyPath === field) ??
+    metadata.columns.find((column) => column.databaseName === field) ??
+    metadata.columns.find((column) => column.databasePath === field) ??
+    null
+  );
+}
+
+export function resolveModelRepository(
+  context: PersistenceContext,
+  model: string,
+): ModelRepositoryContext {
+  const target = context.models[model];
+
+  if (!target) {
+    throw createMissingModelMappingError(model);
+  }
+
+  const repository = context.manager.getRepository(target);
+
+  return {
+    model,
+    target,
+    repository,
+    metadata: repository.metadata,
+  };
+}
+
+export function resolveField(
+  repositoryContext: ModelRepositoryContext,
+  field: string,
+): ResolvedField {
+  const column = findColumn(repositoryContext.metadata, field);
+
+  if (!column) {
+    throw createUnresolvedFieldError(repositoryContext.model, field);
+  }
+
+  return {
+    inputName: field,
+    propertyName: column.propertyName,
+    propertyPath: column.propertyPath,
+    databaseName: column.databaseName,
+  };
+}
+
+export function getSinglePrimaryField(
+  repositoryContext: ModelRepositoryContext,
+): ResolvedField {
+  if (repositoryContext.metadata.primaryColumns.length !== 1) {
+    throw createUnsupportedPrimaryKeyError(repositoryContext.model);
+  }
+
+  const [primaryColumn] = repositoryContext.metadata.primaryColumns;
+
+  return {
+    inputName: primaryColumn.databaseName,
+    propertyName: primaryColumn.propertyName,
+    propertyPath: primaryColumn.propertyPath,
+    databaseName: primaryColumn.databaseName,
+  };
+}

--- a/packages/better-auth/typeorm-adapter/src/lib/internal/query-builder.ts
+++ b/packages/better-auth/typeorm-adapter/src/lib/internal/query-builder.ts
@@ -1,0 +1,193 @@
+import type { CleanedWhere } from 'better-auth/adapters';
+import type { ObjectLiteral, SelectQueryBuilder } from 'typeorm';
+
+import type { ModelRepositoryContext, ResolvedField } from './metadata.js';
+import { resolveField } from './metadata.js';
+
+type WhereCapableQueryBuilder = Pick<
+  SelectQueryBuilder<ObjectLiteral>,
+  'where' | 'andWhere' | 'orWhere'
+>;
+
+const DEFAULT_ALIAS = 'entity';
+
+let parameterCounter = 0;
+
+function nextParameterName(): string {
+  parameterCounter += 1;
+  return `where_${parameterCounter}`;
+}
+
+function createClauseExpression(
+  resolvedField: ResolvedField,
+  where: CleanedWhere,
+  alias: string,
+): { expression: string; parameters: Record<string, unknown> } {
+  const fieldExpression = `${alias}.${resolvedField.propertyPath}`;
+  const operator = where.operator;
+  const value = where.value;
+
+  if (operator === 'eq' && value === null) {
+    return { expression: `${fieldExpression} IS NULL`, parameters: {} };
+  }
+
+  if (operator === 'ne' && value === null) {
+    return { expression: `${fieldExpression} IS NOT NULL`, parameters: {} };
+  }
+
+  if (operator === 'in' || operator === 'not_in') {
+    const values = Array.isArray(value) ? value : [value];
+    const withoutNull = values.filter((entry) => entry !== null);
+    const hasNull = values.length !== withoutNull.length;
+
+    if (withoutNull.length === 0 && !hasNull) {
+      return {
+        expression: operator === 'in' ? '1 = 0' : '1 = 1',
+        parameters: {},
+      };
+    }
+
+    if (withoutNull.length === 0 && hasNull) {
+      return {
+        expression:
+          operator === 'in'
+            ? `${fieldExpression} IS NULL`
+            : `${fieldExpression} IS NOT NULL`,
+        parameters: {},
+      };
+    }
+
+    const parameterName = nextParameterName();
+    const baseExpression =
+      operator === 'in'
+        ? `${fieldExpression} IN (:...${parameterName})`
+        : `${fieldExpression} NOT IN (:...${parameterName})`;
+
+    if (!hasNull) {
+      return {
+        expression: baseExpression,
+        parameters: { [parameterName]: withoutNull },
+      };
+    }
+
+    return {
+      expression:
+        operator === 'in'
+          ? `(${baseExpression} OR ${fieldExpression} IS NULL)`
+          : `(${baseExpression} AND ${fieldExpression} IS NOT NULL)`,
+      parameters: { [parameterName]: withoutNull },
+    };
+  }
+
+  const parameterName = nextParameterName();
+
+  if (operator === 'contains') {
+    return {
+      expression: `${fieldExpression} LIKE :${parameterName}`,
+      parameters: { [parameterName]: `%${String(value)}%` },
+    };
+  }
+
+  if (operator === 'starts_with') {
+    return {
+      expression: `${fieldExpression} LIKE :${parameterName}`,
+      parameters: { [parameterName]: `${String(value)}%` },
+    };
+  }
+
+  if (operator === 'ends_with') {
+    return {
+      expression: `${fieldExpression} LIKE :${parameterName}`,
+      parameters: { [parameterName]: `%${String(value)}` },
+    };
+  }
+
+  const sqlOperator =
+    operator === 'eq'
+      ? '='
+      : operator === 'ne'
+        ? '!='
+        : operator === 'lt'
+          ? '<'
+          : operator === 'lte'
+            ? '<='
+            : operator === 'gt'
+              ? '>'
+              : '>=';
+
+  return {
+    expression: `${fieldExpression} ${sqlOperator} :${parameterName}`,
+    parameters: { [parameterName]: value },
+  };
+}
+
+export function applyWhereClauses(
+  queryBuilder: WhereCapableQueryBuilder,
+  repositoryContext: ModelRepositoryContext,
+  where: CleanedWhere[] | undefined,
+  alias = DEFAULT_ALIAS,
+): void {
+  if (!where || where.length === 0) {
+    return;
+  }
+
+  where.forEach((clause, index) => {
+    const resolvedField = resolveField(repositoryContext, clause.field);
+    const { expression, parameters } = createClauseExpression(
+      resolvedField,
+      clause,
+      alias,
+    );
+
+    if (index === 0) {
+      queryBuilder.where(expression, parameters);
+      return;
+    }
+
+    if (clause.connector === 'OR') {
+      queryBuilder.orWhere(expression, parameters);
+      return;
+    }
+
+    queryBuilder.andWhere(expression, parameters);
+  });
+}
+
+export function applySortAndPagination(
+  queryBuilder: SelectQueryBuilder<ObjectLiteral>,
+  repositoryContext: ModelRepositoryContext,
+  options: {
+    sortBy?:
+      | {
+          field: string;
+          direction: 'asc' | 'desc';
+        }
+      | undefined;
+    limit?: number | undefined;
+    offset?: number | undefined;
+  },
+  alias = DEFAULT_ALIAS,
+): void {
+  if (options.sortBy) {
+    const resolvedField = resolveField(repositoryContext, options.sortBy.field);
+    queryBuilder.orderBy(
+      `${alias}.${resolvedField.propertyPath}`,
+      options.sortBy.direction.toUpperCase() as 'ASC' | 'DESC',
+    );
+  }
+
+  if (typeof options.limit === 'number') {
+    queryBuilder.take(options.limit);
+  }
+
+  if (typeof options.offset === 'number') {
+    queryBuilder.skip(options.offset);
+  }
+}
+
+export function createRepositoryQueryBuilder(
+  repositoryContext: ModelRepositoryContext,
+  alias = DEFAULT_ALIAS,
+): SelectQueryBuilder<ObjectLiteral> {
+  return repositoryContext.repository.createQueryBuilder(alias);
+}


### PR DESCRIPTION
Implement the internal TypeORM persistence layer for the Better Auth adapter package, including model and field resolution, cleaned where translation, CRUD operations, join hydration, transaction scoping, and unit coverage for the new persistence behavior.

Closes #7 Refs #4