### PR TITLE
feat(nest-angular-ssr): expose public Angular SSR registration path

### DIFF
--- a/apps/fixtures/nest-cjs-consumer/src/app/app.module.ts
+++ b/apps/fixtures/nest-cjs-consumer/src/app/app.module.ts
@@ -5,10 +5,12 @@ import { NestAngularSsrModule } from '@anarchitects/nest-angular-ssr';
 import { join } from 'node:path';
 
 import { HealthController } from './health.controller';
+import { fixtureAngularSsrRegistration } from '../ssr/angular-ssr-fixture';
 
 @Module({
   imports: [
     NestAngularSsrModule.forRoot({
+      angular: fixtureAngularSsrRegistration,
       routing: {
         browserAssetsDir: join(process.cwd(), 'src/assets/browser'),
       },

--- a/apps/fixtures/nest-cjs-consumer/src/index.server.html
+++ b/apps/fixtures/nest-cjs-consumer/src/index.server.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Nest CJS Consumer Fixture</title>
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/apps/fixtures/nest-cjs-consumer/src/main.server.ts
+++ b/apps/fixtures/nest-cjs-consumer/src/main.server.ts
@@ -1,0 +1,50 @@
+import '@angular/compiler';
+
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  bootstrapApplication,
+  type BootstrapContext,
+} from '@angular/platform-browser';
+import { provideRouter, RouterOutlet, type Routes } from '@angular/router';
+import {
+  RenderMode,
+  provideServerRendering,
+  type ServerRoute,
+  withRoutes,
+} from '@angular/ssr';
+
+const FixtureAppComponent = Component({
+  selector: 'app-root',
+  imports: [RouterOutlet],
+  template: `<router-outlet />`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})(class FixtureAppComponent {});
+
+const FixtureHomeComponent = Component({
+  selector: 'fixture-home',
+  template: `
+    <main>
+      <h1>Nest CJS Consumer Fixture</h1>
+      <p>SSR response rendered from the CommonJS-oriented Nest fixture.</p>
+    </main>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})(class FixtureHomeComponent {});
+
+const appRoutes: Routes = [{ path: '', component: FixtureHomeComponent }];
+const serverRoutes: ServerRoute[] = [
+  { path: '', renderMode: RenderMode.Server },
+];
+
+export async function bootstrapServerApplication(context: BootstrapContext) {
+  return bootstrapApplication(
+    FixtureAppComponent,
+    {
+      providers: [
+        provideRouter(appRoutes),
+        provideServerRendering(withRoutes(serverRoutes)),
+      ],
+    },
+    context,
+  );
+}

--- a/apps/fixtures/nest-cjs-consumer/src/main.ts
+++ b/apps/fixtures/nest-cjs-consumer/src/main.ts
@@ -7,12 +7,9 @@ import {
 } from '@nestjs/platform-fastify';
 
 import { AppModule } from './app/app.module';
-import { setupAngularSsrFixture } from './ssr/angular-ssr-fixture';
 
 async function bootstrap() {
   const port = Number(process.env.PORT ?? '3311');
-
-  await setupAngularSsrFixture();
 
   const app = await NestFactory.create<NestFastifyApplication>(
     AppModule,

--- a/apps/fixtures/nest-cjs-consumer/src/ssr/angular-ssr-fixture.ts
+++ b/apps/fixtures/nest-cjs-consumer/src/ssr/angular-ssr-fixture.ts
@@ -1,68 +1,11 @@
-import '@angular/compiler';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import {
-  bootstrapApplication,
-  type BootstrapContext,
-} from '@angular/platform-browser';
-import { provideRouter, RouterOutlet, type Routes } from '@angular/router';
-import {
-  RenderMode,
-  provideServerRendering,
-  type ServerRoute,
-  withRoutes,
-} from '@angular/ssr';
 import type { AngularSsrRegistrationOptions } from '@anarchitects/nest-angular-ssr';
+import { join } from 'node:path';
 
-const INDEX_SERVER_HTML = `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>Nest CJS Consumer Fixture</title>
-  </head>
-  <body>
-    <app-root></app-root>
-  </body>
-</html>`;
-
-const FixtureAppComponent = Component({
-  selector: 'app-root',
-  imports: [RouterOutlet],
-  template: `<router-outlet />`,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-})(class FixtureAppComponent {});
-
-const FixtureHomeComponent = Component({
-  selector: 'fixture-home',
-  template: `
-    <main>
-      <h1>Nest CJS Consumer Fixture</h1>
-      <p>SSR response rendered from the CommonJS-oriented Nest fixture.</p>
-    </main>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-})(class FixtureHomeComponent {});
-
-const appRoutes: Routes = [{ path: '', component: FixtureHomeComponent }];
-const serverRoutes: ServerRoute[] = [
-  { path: '', renderMode: RenderMode.Server },
-];
-
-async function bootstrapFixtureApplication(context: BootstrapContext) {
-  return bootstrapApplication(
-    FixtureAppComponent,
-    {
-      providers: [
-        provideRouter(appRoutes),
-        provideServerRendering(withRoutes(serverRoutes)),
-      ],
-    },
-    context,
-  );
-}
+import { bootstrapServerApplication } from '../main.server';
 
 export const fixtureAngularSsrRegistration = {
-  bootstrap: async () => bootstrapFixtureApplication,
-  document: INDEX_SERVER_HTML,
+  bootstrap: async () => bootstrapServerApplication,
+  templatePath: join(process.cwd(), 'src/index.server.html'),
   inlineCriticalCss: false,
   routeExtractionUrl: 'http://127.0.0.1/',
   allowedHosts: ['127.0.0.1', 'localhost'],

--- a/apps/fixtures/nest-cjs-consumer/src/ssr/angular-ssr-fixture.ts
+++ b/apps/fixtures/nest-cjs-consumer/src/ssr/angular-ssr-fixture.ts
@@ -1,5 +1,3 @@
-import { createHash } from 'node:crypto';
-
 import '@angular/compiler';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import {
@@ -12,12 +10,8 @@ import {
   provideServerRendering,
   type ServerRoute,
   withRoutes,
-  ɵdestroyAngularServerApp,
-  ɵextractRoutesAndCreateRouteTree,
-  ɵgetOrCreateAngularServerApp,
-  ɵsetAngularAppEngineManifest,
-  ɵsetAngularAppManifest,
 } from '@angular/ssr';
+import type { AngularSsrRegistrationOptions } from '@anarchitects/nest-angular-ssr';
 
 const INDEX_SERVER_HTML = `<!doctype html>
 <html lang="en">
@@ -53,14 +47,6 @@ const serverRoutes: ServerRoute[] = [
   { path: '', renderMode: RenderMode.Server },
 ];
 
-function createServerAsset(text: string) {
-  return {
-    text: async () => text,
-    hash: createHash('sha256').update(text).digest('hex'),
-    size: Buffer.byteLength(text),
-  };
-}
-
 async function bootstrapFixtureApplication(context: BootstrapContext) {
   return bootstrapApplication(
     FixtureAppComponent,
@@ -74,39 +60,10 @@ async function bootstrapFixtureApplication(context: BootstrapContext) {
   );
 }
 
-export async function setupAngularSsrFixture(url = 'http://127.0.0.1/') {
-  const manifest = {
-    baseHref: '/',
-    assets: {
-      'index.server.html': createServerAsset(INDEX_SERVER_HTML),
-    },
-    bootstrap: async () => bootstrapFixtureApplication,
-    inlineCriticalCss: false,
-  } as const;
-
-  const { routeTree, errors } = await ɵextractRoutesAndCreateRouteTree({
-    url: new URL(url),
-    manifest,
-  });
-
-  if (errors.length > 0) {
-    throw new Error(errors.join('\n'));
-  }
-
-  ɵdestroyAngularServerApp();
-  ɵsetAngularAppManifest({
-    ...manifest,
-    routes: routeTree.toObject(),
-  });
-  ɵsetAngularAppEngineManifest({
-    entryPoints: {
-      '': async () => ({
-        ɵgetOrCreateAngularServerApp,
-        ɵdestroyAngularServerApp,
-      }),
-    },
-    basePath: '/',
-    supportedLocales: {},
-    allowedHosts: ['127.0.0.1', 'localhost'],
-  });
-}
+export const fixtureAngularSsrRegistration = {
+  bootstrap: async () => bootstrapFixtureApplication,
+  document: INDEX_SERVER_HTML,
+  inlineCriticalCss: false,
+  routeExtractionUrl: 'http://127.0.0.1/',
+  allowedHosts: ['127.0.0.1', 'localhost'],
+} satisfies AngularSsrRegistrationOptions;

--- a/apps/fixtures/nest-esm-consumer/src/app/app.module.ts
+++ b/apps/fixtures/nest-esm-consumer/src/app/app.module.ts
@@ -5,10 +5,12 @@ import { NestAngularSsrModule } from '@anarchitects/nest-angular-ssr';
 import { join } from 'node:path';
 
 import { HealthController } from './health.controller.js';
+import { fixtureAngularSsrRegistration } from '../ssr/angular-ssr-fixture.js';
 
 @Module({
   imports: [
     NestAngularSsrModule.forRoot({
+      angular: fixtureAngularSsrRegistration,
       routing: {
         browserAssetsDir: join(process.cwd(), 'src/assets/browser'),
       },

--- a/apps/fixtures/nest-esm-consumer/src/index.server.html
+++ b/apps/fixtures/nest-esm-consumer/src/index.server.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Nest ESM Consumer Fixture</title>
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/apps/fixtures/nest-esm-consumer/src/main.server.ts
+++ b/apps/fixtures/nest-esm-consumer/src/main.server.ts
@@ -1,0 +1,50 @@
+import '@angular/compiler';
+
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  bootstrapApplication,
+  type BootstrapContext,
+} from '@angular/platform-browser';
+import { provideRouter, RouterOutlet, type Routes } from '@angular/router';
+import {
+  RenderMode,
+  provideServerRendering,
+  type ServerRoute,
+  withRoutes,
+} from '@angular/ssr';
+
+const FixtureAppComponent = Component({
+  selector: 'app-root',
+  imports: [RouterOutlet],
+  template: `<router-outlet />`,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})(class FixtureAppComponent {});
+
+const FixtureHomeComponent = Component({
+  selector: 'fixture-home',
+  template: `
+    <main>
+      <h1>Nest ESM Consumer Fixture</h1>
+      <p>SSR response rendered from the ESM-oriented Nest fixture.</p>
+    </main>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})(class FixtureHomeComponent {});
+
+const appRoutes: Routes = [{ path: '', component: FixtureHomeComponent }];
+const serverRoutes: ServerRoute[] = [
+  { path: '', renderMode: RenderMode.Server },
+];
+
+export async function bootstrapServerApplication(context: BootstrapContext) {
+  return bootstrapApplication(
+    FixtureAppComponent,
+    {
+      providers: [
+        provideRouter(appRoutes),
+        provideServerRendering(withRoutes(serverRoutes)),
+      ],
+    },
+    context,
+  );
+}

--- a/apps/fixtures/nest-esm-consumer/src/main.ts
+++ b/apps/fixtures/nest-esm-consumer/src/main.ts
@@ -6,12 +6,9 @@ import {
   type NestFastifyApplication,
 } from '@nestjs/platform-fastify';
 import { AppModule } from './app/app.module.js';
-import { setupAngularSsrFixture } from './ssr/angular-ssr-fixture.js';
 
 async function bootstrap() {
   const port = Number(process.env.PORT ?? '3312');
-
-  await setupAngularSsrFixture();
 
   const app = await NestFactory.create<NestFastifyApplication>(
     AppModule,

--- a/apps/fixtures/nest-esm-consumer/src/ssr/angular-ssr-fixture.ts
+++ b/apps/fixtures/nest-esm-consumer/src/ssr/angular-ssr-fixture.ts
@@ -1,68 +1,11 @@
-import '@angular/compiler';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import {
-  bootstrapApplication,
-  type BootstrapContext,
-} from '@angular/platform-browser';
-import { provideRouter, RouterOutlet, type Routes } from '@angular/router';
-import {
-  RenderMode,
-  provideServerRendering,
-  type ServerRoute,
-  withRoutes,
-} from '@angular/ssr';
 import type { AngularSsrRegistrationOptions } from '@anarchitects/nest-angular-ssr';
+import { join } from 'node:path';
 
-const INDEX_SERVER_HTML = `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>Nest ESM Consumer Fixture</title>
-  </head>
-  <body>
-    <app-root></app-root>
-  </body>
-</html>`;
-
-const FixtureAppComponent = Component({
-  selector: 'app-root',
-  imports: [RouterOutlet],
-  template: `<router-outlet />`,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-})(class FixtureAppComponent {});
-
-const FixtureHomeComponent = Component({
-  selector: 'fixture-home',
-  template: `
-    <main>
-      <h1>Nest ESM Consumer Fixture</h1>
-      <p>SSR response rendered from the ESM-oriented Nest fixture.</p>
-    </main>
-  `,
-  changeDetection: ChangeDetectionStrategy.OnPush,
-})(class FixtureHomeComponent {});
-
-const appRoutes: Routes = [{ path: '', component: FixtureHomeComponent }];
-const serverRoutes: ServerRoute[] = [
-  { path: '', renderMode: RenderMode.Server },
-];
-
-async function bootstrapFixtureApplication(context: BootstrapContext) {
-  return bootstrapApplication(
-    FixtureAppComponent,
-    {
-      providers: [
-        provideRouter(appRoutes),
-        provideServerRendering(withRoutes(serverRoutes)),
-      ],
-    },
-    context,
-  );
-}
+import { bootstrapServerApplication } from '../main.server.js';
 
 export const fixtureAngularSsrRegistration = {
-  bootstrap: async () => bootstrapFixtureApplication,
-  document: INDEX_SERVER_HTML,
+  bootstrap: async () => bootstrapServerApplication,
+  templatePath: join(process.cwd(), 'src/index.server.html'),
   inlineCriticalCss: false,
   routeExtractionUrl: 'http://127.0.0.1/',
   allowedHosts: ['127.0.0.1', 'localhost'],

--- a/apps/fixtures/nest-esm-consumer/src/ssr/angular-ssr-fixture.ts
+++ b/apps/fixtures/nest-esm-consumer/src/ssr/angular-ssr-fixture.ts
@@ -1,5 +1,3 @@
-import { createHash } from 'node:crypto';
-
 import '@angular/compiler';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import {
@@ -12,12 +10,8 @@ import {
   provideServerRendering,
   type ServerRoute,
   withRoutes,
-  ɵdestroyAngularServerApp,
-  ɵextractRoutesAndCreateRouteTree,
-  ɵgetOrCreateAngularServerApp,
-  ɵsetAngularAppEngineManifest,
-  ɵsetAngularAppManifest,
 } from '@angular/ssr';
+import type { AngularSsrRegistrationOptions } from '@anarchitects/nest-angular-ssr';
 
 const INDEX_SERVER_HTML = `<!doctype html>
 <html lang="en">
@@ -53,14 +47,6 @@ const serverRoutes: ServerRoute[] = [
   { path: '', renderMode: RenderMode.Server },
 ];
 
-function createServerAsset(text: string) {
-  return {
-    text: async () => text,
-    hash: createHash('sha256').update(text).digest('hex'),
-    size: Buffer.byteLength(text),
-  };
-}
-
 async function bootstrapFixtureApplication(context: BootstrapContext) {
   return bootstrapApplication(
     FixtureAppComponent,
@@ -74,39 +60,10 @@ async function bootstrapFixtureApplication(context: BootstrapContext) {
   );
 }
 
-export async function setupAngularSsrFixture(url = 'http://127.0.0.1/') {
-  const manifest = {
-    baseHref: '/',
-    assets: {
-      'index.server.html': createServerAsset(INDEX_SERVER_HTML),
-    },
-    bootstrap: async () => bootstrapFixtureApplication,
-    inlineCriticalCss: false,
-  } as const;
-
-  const { routeTree, errors } = await ɵextractRoutesAndCreateRouteTree({
-    url: new URL(url),
-    manifest,
-  });
-
-  if (errors.length > 0) {
-    throw new Error(errors.join('\n'));
-  }
-
-  ɵdestroyAngularServerApp();
-  ɵsetAngularAppManifest({
-    ...manifest,
-    routes: routeTree.toObject(),
-  });
-  ɵsetAngularAppEngineManifest({
-    entryPoints: {
-      '': async () => ({
-        ɵgetOrCreateAngularServerApp,
-        ɵdestroyAngularServerApp,
-      }),
-    },
-    basePath: '/',
-    supportedLocales: {},
-    allowedHosts: ['127.0.0.1', 'localhost'],
-  });
-}
+export const fixtureAngularSsrRegistration = {
+  bootstrap: async () => bootstrapFixtureApplication,
+  document: INDEX_SERVER_HTML,
+  inlineCriticalCss: false,
+  routeExtractionUrl: 'http://127.0.0.1/',
+  allowedHosts: ['127.0.0.1', 'localhost'],
+} satisfies AngularSsrRegistrationOptions;

--- a/packages/nest/angular-ssr/README.md
+++ b/packages/nest/angular-ssr/README.md
@@ -33,6 +33,7 @@ The compatibility result above is backed by the fixture validation note at [`doc
 - NestJS 11+ with the Fastify adapter
 - Angular SSR built on `@angular/ssr`
 - An explicit browser assets directory
+- An app-owned Angular server bootstrap entry or bootstrap function
 
 Peer dependencies:
 
@@ -49,12 +50,29 @@ Peer dependencies:
 Use the module when you want a normal Nest `AppModule`-based setup.
 
 ```ts
+import type { BootstrapContext } from '@angular/platform-browser';
 import { Module } from '@nestjs/common';
-import { NestAngularSsrModule } from '@anarchitects/nest-angular-ssr';
+import {
+  type AngularSsrRegistrationOptions,
+  NestAngularSsrModule,
+} from '@anarchitects/nest-angular-ssr';
+
+const angular = {
+  bootstrap: async () => bootstrapServerApplication,
+  document: `<!doctype html><html><body><app-root></app-root></body></html>`,
+  routeExtractionUrl: 'http://127.0.0.1/',
+  allowedHosts: ['127.0.0.1', 'localhost'],
+  inlineCriticalCss: false,
+} satisfies AngularSsrRegistrationOptions;
+
+async function bootstrapServerApplication(context: BootstrapContext) {
+  return bootstrapApplication(AppComponent, appConfig, context);
+}
 
 @Module({
   imports: [
     NestAngularSsrModule.forRoot({
+      angular,
       routing: {
         browserAssetsDir: 'dist/apps/web/browser',
       },
@@ -89,6 +107,12 @@ void bootstrap();
 Notes:
 
 - `browserAssetsDir` is required.
+- `angular.bootstrap` is required and remains application-owned.
+- `angular.document` should contain the server HTML document, typically your `index.server.html` content.
+- `angular.baseHref` defaults to `'/'`.
+- `angular.inlineCriticalCss` defaults to `false`.
+- `angular.routeExtractionUrl` defaults to `http://localhost/`.
+- `angular.allowedHosts` is optional. Leave it unset unless you want explicit host restrictions for the Angular SSR engine.
 - When your app uses `app.setGlobalPrefix(...)`, SSR routing follows that prefix automatically.
 - Set `routing.apiPrefix` only when you need to override the detected Nest global prefix.
 - `NestAngularSsrModule.forRootAsync(...)` is available when the same option shape needs to come from Nest DI or async config.
@@ -97,6 +121,10 @@ Notes:
 NestAngularSsrModule.forRootAsync({
   inject: [ConfigService],
   useFactory: (config: ConfigService) => ({
+    angular: {
+      bootstrap: async () => bootstrapServerApplication,
+      document: config.getOrThrow<string>('WEB_INDEX_SERVER_HTML'),
+    },
     routing: {
       browserAssetsDir: config.getOrThrow<string>('WEB_BROWSER_ASSETS_DIR'),
     },
@@ -127,6 +155,10 @@ async function bootstrap() {
   app.setGlobalPrefix('api');
 
   await bootstrapNestAngularSsr(app, {
+    angular: {
+      bootstrap: async () => bootstrapServerApplication,
+      document: `<!doctype html><html><body><app-root></app-root></body></html>`,
+    },
     routing: {
       browserAssetsDir: 'dist/apps/web/browser',
     },
@@ -138,8 +170,9 @@ async function bootstrap() {
 void bootstrap();
 ```
 
-`BootstrapNestAngularSsrOptions` keeps two explicit groups:
+`BootstrapNestAngularSsrOptions` keeps three explicit groups:
 
+- `angular`: public Angular SSR registration/bootstrap input
 - `integration`: renderer injection or request-context customization
 - `routing`: browser assets directory and optional API-prefix override
 
@@ -152,6 +185,8 @@ Use the lower-level APIs only if the module or bootstrap helper is too opinionat
 - `createNestAngularSsrIntegration(...)`
 - `registerNestAngularSsrRoutes(...)`
 
+At the renderer layer, `createAngularSsrRenderer({ registration })` is the advanced entry point for package-owned Angular registration without the Nest module/bootstrap helpers.
+
 These APIs keep the public boundary small:
 
 - SSR core stays on Web `Request` / `Response`
@@ -160,7 +195,15 @@ These APIs keep the public boundary small:
 
 ## Existing Option Shapes
 
+- `AngularSsrRegistrationOptions`
+  - `bootstrap: AngularSsrServerBootstrapLoader`
+  - `document: string`
+  - `baseHref?: string`
+  - `inlineCriticalCss?: boolean`
+  - `routeExtractionUrl?: string | URL`
+  - `allowedHosts?: readonly string[]`
 - `AngularNodeSsrRendererOptions`
+  - `registration?: AngularSsrRegistrationOptions`
   - `engine?: AngularNodeAppEngine`
   - `engineOptions?: AngularNodeAppEngineOptions`
 - `CreateNestAngularSsrIntegrationOptions<TContext>`
@@ -171,6 +214,7 @@ These APIs keep the public boundary small:
   - `browserAssetsDir: string`
   - `apiPrefix?: string`
 - `BootstrapNestAngularSsrOptions<TContext>`
+  - `angular?: AngularSsrRegistrationOptions`
   - `integration?: CreateNestAngularSsrIntegrationOptions<TContext>`
   - `routing: RegisterNestAngularSsrRoutesOptions`
 - `NestAngularSsrModuleOptions<TContext>`
@@ -178,8 +222,12 @@ These APIs keep the public boundary small:
 
 The mutually exclusive pairs are enforced in code:
 
+- renderer `registration` vs `engine`
+- renderer `registration` vs `engineOptions`
 - renderer `engine` vs `engineOptions`
 - integration `renderer` vs `rendererOptions`
+- bootstrap `angular` vs `integration.renderer`
+- bootstrap `angular` vs `integration.rendererOptions`
 
 ## Constraints and Non-Goals
 
@@ -188,6 +236,7 @@ v1 intentionally does not do the following:
 - support Express or non-Fastify Nest adapters
 - use `ServeStaticModule`
 - add hidden auto-bootstrap outside the Nest module lifecycle or explicit helper call
+- take ownership of your Angular server bootstrap implementation
 - claim support for every Nest/Angular deployment shape
 - recreate legacy Universal APIs exactly
 

--- a/packages/nest/angular-ssr/README.md
+++ b/packages/nest/angular-ssr/README.md
@@ -50,24 +50,21 @@ Peer dependencies:
 Use the module when you want a normal Nest `AppModule`-based setup.
 
 ```ts
-import type { BootstrapContext } from '@angular/platform-browser';
 import { Module } from '@nestjs/common';
+import { join } from 'node:path';
 import {
   type AngularSsrRegistrationOptions,
   NestAngularSsrModule,
 } from '@anarchitects/nest-angular-ssr';
+import { bootstrapServerApplication } from './main.server';
 
 const angular = {
   bootstrap: async () => bootstrapServerApplication,
-  document: `<!doctype html><html><body><app-root></app-root></body></html>`,
+  templatePath: join(process.cwd(), 'src/index.server.html'),
   routeExtractionUrl: 'http://127.0.0.1/',
   allowedHosts: ['127.0.0.1', 'localhost'],
   inlineCriticalCss: false,
 } satisfies AngularSsrRegistrationOptions;
-
-async function bootstrapServerApplication(context: BootstrapContext) {
-  return bootstrapApplication(AppComponent, appConfig, context);
-}
 
 @Module({
   imports: [
@@ -108,11 +105,12 @@ Notes:
 
 - `browserAssetsDir` is required.
 - `angular.bootstrap` is required and remains application-owned.
-- `angular.document` should contain the server HTML document, typically your `index.server.html` content.
+- `angular.templatePath` should point to your server HTML document, typically `src/index.server.html`.
 - `angular.baseHref` defaults to `'/'`.
 - `angular.inlineCriticalCss` defaults to `false`.
 - `angular.routeExtractionUrl` defaults to `http://localhost/`.
 - `angular.allowedHosts` is optional. Leave it unset unless you want explicit host restrictions for the Angular SSR engine.
+- Angular/Nx SSR generator output can usually be reused directly: keep your `main.server.ts` as the bootstrap entry and point `templatePath` at the generated `index.server.html`.
 - When your app uses `app.setGlobalPrefix(...)`, SSR routing follows that prefix automatically.
 - Set `routing.apiPrefix` only when you need to override the detected Nest global prefix.
 - `NestAngularSsrModule.forRootAsync(...)` is available when the same option shape needs to come from Nest DI or async config.
@@ -123,7 +121,7 @@ NestAngularSsrModule.forRootAsync({
   useFactory: (config: ConfigService) => ({
     angular: {
       bootstrap: async () => bootstrapServerApplication,
-      document: config.getOrThrow<string>('WEB_INDEX_SERVER_HTML'),
+      templatePath: config.getOrThrow<string>('WEB_INDEX_SERVER_TEMPLATE'),
     },
     routing: {
       browserAssetsDir: config.getOrThrow<string>('WEB_BROWSER_ASSETS_DIR'),
@@ -138,6 +136,7 @@ Use this when you want explicit bootstrap wiring in `main.ts`.
 
 ```ts
 import { NestFactory } from '@nestjs/core';
+import { join } from 'node:path';
 import {
   FastifyAdapter,
   type NestFastifyApplication,
@@ -145,6 +144,7 @@ import {
 import { bootstrapNestAngularSsr } from '@anarchitects/nest-angular-ssr';
 
 import { AppModule } from './app.module';
+import { bootstrapServerApplication } from './main.server';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
@@ -157,7 +157,7 @@ async function bootstrap() {
   await bootstrapNestAngularSsr(app, {
     angular: {
       bootstrap: async () => bootstrapServerApplication,
-      document: `<!doctype html><html><body><app-root></app-root></body></html>`,
+      templatePath: join(process.cwd(), 'src/index.server.html'),
     },
     routing: {
       browserAssetsDir: 'dist/apps/web/browser',
@@ -187,6 +187,18 @@ Use the lower-level APIs only if the module or bootstrap helper is too opinionat
 
 At the renderer layer, `createAngularSsrRenderer({ registration })` is the advanced entry point for package-owned Angular registration without the Nest module/bootstrap helpers.
 
+If you want to normalize a template file up front, use `createAngularSsrRegistration(...)`:
+
+```ts
+import { join } from 'node:path';
+import { createAngularSsrRegistration } from '@anarchitects/nest-angular-ssr';
+
+const registration = await createAngularSsrRegistration({
+  bootstrap: async () => bootstrapServerApplication,
+  templatePath: join(process.cwd(), 'src/index.server.html'),
+});
+```
+
 These APIs keep the public boundary small:
 
 - SSR core stays on Web `Request` / `Response`
@@ -197,13 +209,21 @@ These APIs keep the public boundary small:
 
 - `AngularSsrRegistrationOptions`
   - `bootstrap: AngularSsrServerBootstrapLoader`
+  - `templatePath: string`
+  - `baseHref?: string`
+  - `inlineCriticalCss?: boolean`
+  - `routeExtractionUrl?: string | URL`
+  - `allowedHosts?: readonly string[]`
+- `ResolvedAngularSsrRegistrationOptions`
+  - `bootstrap: AngularSsrServerBootstrapLoader`
+  - `templatePath: string`
   - `document: string`
   - `baseHref?: string`
   - `inlineCriticalCss?: boolean`
   - `routeExtractionUrl?: string | URL`
   - `allowedHosts?: readonly string[]`
 - `AngularNodeSsrRendererOptions`
-  - `registration?: AngularSsrRegistrationOptions`
+  - `registration?: AngularSsrRegistrationOptions | ResolvedAngularSsrRegistrationOptions`
   - `engine?: AngularNodeAppEngine`
   - `engineOptions?: AngularNodeAppEngineOptions`
 - `CreateNestAngularSsrIntegrationOptions<TContext>`

--- a/packages/nest/angular-ssr/src/index.ts
+++ b/packages/nest/angular-ssr/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lib/core/angular-ssr-contract.js';
+export * from './lib/core/angular-ssr-registration.js';
 export * from './lib/core/angular-node-ssr-renderer.js';
 export * from './lib/nest/nest-angular-ssr-bootstrap.js';
 export * from './lib/nest/nest-angular-ssr-integration.js';

--- a/packages/nest/angular-ssr/src/lib/core/angular-node-ssr-renderer.spec.ts
+++ b/packages/nest/angular-ssr/src/lib/core/angular-node-ssr-renderer.spec.ts
@@ -5,11 +5,16 @@ import {
   AngularNodeSsrRenderer,
   createAngularSsrRenderer,
 } from './angular-node-ssr-renderer.js';
-import { setupAngularSsrFixture } from '../../testing/angular-ssr-fixture.js';
+import {
+  cleanupAngularSsrFixture,
+  createAngularSsrFixtureRegistration,
+  setupAngularSsrFixture,
+} from '../../testing/angular-ssr-fixture.js';
 
 describe('AngularNodeSsrRenderer', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    cleanupAngularSsrFixture();
   });
 
   it('returns a renderer instance from the factory', () => {
@@ -71,6 +76,44 @@ describe('AngularNodeSsrRenderer', () => {
           engineOptions: { allowedHosts: ['localhost'] },
         }),
     ).toThrow('Cannot provide both "engine" and "engineOptions"');
+  });
+
+  it('rejects ambiguous configuration when registration is provided with an engine', () => {
+    const engine = {
+      handle: vi.fn(),
+    } as unknown as AngularNodeAppEngine;
+
+    expect(
+      () =>
+        new AngularNodeSsrRenderer({
+          registration: createAngularSsrFixtureRegistration(),
+          engine,
+        }),
+    ).toThrow('Cannot provide "registration" together with "engine"');
+  });
+
+  it('rejects ambiguous configuration when registration is provided with engine options', () => {
+    expect(
+      () =>
+        new AngularNodeSsrRenderer({
+          registration: createAngularSsrFixtureRegistration(),
+          engineOptions: { allowedHosts: ['localhost'] },
+        }),
+    ).toThrow('Cannot provide "registration" together with "engine"');
+  });
+
+  it('renders a real response when configured with registration options only', async () => {
+    const registration = createAngularSsrFixtureRegistration();
+    const renderer = createAngularSsrRenderer({ registration });
+    const response = await renderer.render(new Request('http://localhost/'));
+
+    expect(response).toBeInstanceOf(Response);
+    expect(response?.status).toBe(200);
+
+    const html = await response?.text();
+
+    expect(html).toContain('SSR Fixture');
+    expect(html).toContain('Angular SSR core fixture');
   });
 
   it('renders a real response with AngularNodeAppEngine', async () => {

--- a/packages/nest/angular-ssr/src/lib/core/angular-node-ssr-renderer.ts
+++ b/packages/nest/angular-ssr/src/lib/core/angular-node-ssr-renderer.ts
@@ -4,11 +4,13 @@ import {
 } from '@angular/ssr/node';
 
 import type { AngularSsrRenderer } from './angular-ssr-contract.js';
-import type { AngularSsrRegistrationOptions } from './angular-ssr-registration.js';
-import { registerAngularSsrApplication } from './angular-ssr-registration-runtime.js';
+import {
+  type AngularSsrRegistrationInput,
+  registerAngularSsrApplication,
+} from './angular-ssr-registration-runtime.js';
 
 export interface AngularNodeSsrRendererOptions {
-  registration?: AngularSsrRegistrationOptions;
+  registration?: AngularSsrRegistrationInput;
   engine?: AngularNodeAppEngine;
   engineOptions?: AngularNodeAppEngineOptions;
 }
@@ -16,7 +18,7 @@ export interface AngularNodeSsrRendererOptions {
 export class AngularNodeSsrRenderer<TContext = unknown>
   implements AngularSsrRenderer<TContext>
 {
-  private readonly registration?: Readonly<AngularSsrRegistrationOptions>;
+  private readonly registration?: Readonly<AngularSsrRegistrationInput>;
   private readonly engineOptions?: AngularNodeAppEngineOptions;
   private engine?: Pick<AngularNodeAppEngine, 'handle'>;
   private registrationPromise?: Promise<void>;

--- a/packages/nest/angular-ssr/src/lib/core/angular-node-ssr-renderer.ts
+++ b/packages/nest/angular-ssr/src/lib/core/angular-node-ssr-renderer.ts
@@ -4,8 +4,11 @@ import {
 } from '@angular/ssr/node';
 
 import type { AngularSsrRenderer } from './angular-ssr-contract.js';
+import type { AngularSsrRegistrationOptions } from './angular-ssr-registration.js';
+import { registerAngularSsrApplication } from './angular-ssr-registration-runtime.js';
 
 export interface AngularNodeSsrRendererOptions {
+  registration?: AngularSsrRegistrationOptions;
   engine?: AngularNodeAppEngine;
   engineOptions?: AngularNodeAppEngineOptions;
 }
@@ -13,10 +16,22 @@ export interface AngularNodeSsrRendererOptions {
 export class AngularNodeSsrRenderer<TContext = unknown>
   implements AngularSsrRenderer<TContext>
 {
-  private readonly engine: Pick<AngularNodeAppEngine, 'handle'>;
+  private readonly registration?: Readonly<AngularSsrRegistrationOptions>;
+  private readonly engineOptions?: AngularNodeAppEngineOptions;
+  private engine?: Pick<AngularNodeAppEngine, 'handle'>;
+  private registrationPromise?: Promise<void>;
 
   constructor(options: Readonly<AngularNodeSsrRendererOptions> = {}) {
-    const { engine, engineOptions } = options;
+    const { registration, engine, engineOptions } = options;
+
+    if (
+      registration &&
+      (engine !== undefined || engineOptions !== undefined)
+    ) {
+      throw new Error(
+        'Cannot provide "registration" together with "engine" or "engineOptions" to AngularNodeSsrRenderer.',
+      );
+    }
 
     if (engine && engineOptions) {
       throw new Error(
@@ -24,14 +39,36 @@ export class AngularNodeSsrRenderer<TContext = unknown>
       );
     }
 
-    this.engine = engine ?? new AngularNodeAppEngine(engineOptions);
+    this.registration = registration;
+    this.engineOptions = engineOptions;
+    this.engine = engine;
   }
 
-  render(
+  async render(
     request: Request,
     requestContext?: TContext,
   ): Promise<Response | null> {
-    return this.engine.handle(request, requestContext);
+    await this.ensureRegistration();
+
+    return this.getEngine().handle(request, requestContext);
+  }
+
+  private async ensureRegistration(): Promise<void> {
+    if (!this.registration) {
+      return;
+    }
+
+    this.registrationPromise ??= registerAngularSsrApplication(
+      this.registration,
+    ).then(() => undefined);
+
+    await this.registrationPromise;
+  }
+
+  private getEngine(): Pick<AngularNodeAppEngine, 'handle'> {
+    this.engine ??= new AngularNodeAppEngine(this.engineOptions);
+
+    return this.engine;
   }
 }
 

--- a/packages/nest/angular-ssr/src/lib/core/angular-ssr-registration-runtime.ts
+++ b/packages/nest/angular-ssr/src/lib/core/angular-ssr-registration-runtime.ts
@@ -1,0 +1,101 @@
+import { createHash } from 'node:crypto';
+
+import {
+  ɵdestroyAngularServerApp as destroyAngularServerApp,
+  ɵextractRoutesAndCreateRouteTree as extractRoutesAndCreateRouteTree,
+  ɵgetOrCreateAngularServerApp as getOrCreateAngularServerApp,
+  ɵsetAngularAppEngineManifest as setAngularAppEngineManifest,
+  ɵsetAngularAppManifest as setAngularAppManifest,
+} from '@angular/ssr';
+
+import type { AngularSsrRegistrationOptions } from './angular-ssr-registration.js';
+
+const DEFAULT_BASE_HREF = '/';
+const DEFAULT_INLINE_CRITICAL_CSS = false;
+const DEFAULT_ROUTE_EXTRACTION_URL = 'http://localhost/';
+const INDEX_SERVER_DOCUMENT_PATH = 'index.server.html';
+
+export interface RegisteredAngularSsrApplication {
+  readonly requestUrl: string;
+  cleanup(): void;
+}
+
+export async function registerAngularSsrApplication(
+  options: Readonly<AngularSsrRegistrationOptions>,
+): Promise<RegisteredAngularSsrApplication> {
+  const requestUrl = createRouteExtractionUrl(options.routeExtractionUrl);
+  const baseHref = normalizeBaseHref(options.baseHref);
+  const manifest = {
+    baseHref,
+    assets: {
+      [INDEX_SERVER_DOCUMENT_PATH]: createServerAsset(options.document),
+    },
+    bootstrap: options.bootstrap,
+    inlineCriticalCss:
+      options.inlineCriticalCss ?? DEFAULT_INLINE_CRITICAL_CSS,
+  } as const;
+  const { routeTree, errors } = await extractRoutesAndCreateRouteTree({
+    url: requestUrl,
+    manifest,
+  });
+
+  if (errors.length > 0) {
+    throw new Error(
+      `Angular SSR route extraction failed:\n${errors.join('\n')}`,
+    );
+  }
+
+  destroyAngularServerApp();
+  setAngularAppManifest({
+    ...manifest,
+    routes: routeTree.toObject(),
+  });
+  setAngularAppEngineManifest({
+    entryPoints: {
+      '': async () => ({
+        ɵgetOrCreateAngularServerApp: getOrCreateAngularServerApp,
+        ɵdestroyAngularServerApp: destroyAngularServerApp,
+      }),
+    },
+    basePath: baseHref,
+    supportedLocales: {},
+    allowedHosts: [...(options.allowedHosts ?? [])],
+  });
+
+  return {
+    requestUrl: requestUrl.toString(),
+    cleanup: resetAngularSsrRegistration,
+  };
+}
+
+export function resetAngularSsrRegistration(): void {
+  destroyAngularServerApp();
+}
+
+function createRouteExtractionUrl(
+  value: AngularSsrRegistrationOptions['routeExtractionUrl'],
+): URL {
+  if (value instanceof URL) {
+    return new URL(value.toString());
+  }
+
+  return new URL(value ?? DEFAULT_ROUTE_EXTRACTION_URL);
+}
+
+function createServerAsset(text: string) {
+  return {
+    text: async () => text,
+    hash: createHash('sha256').update(text).digest('hex'),
+    size: Buffer.byteLength(text),
+  };
+}
+
+function normalizeBaseHref(baseHref: string | undefined): string {
+  const value = baseHref?.trim() ?? DEFAULT_BASE_HREF;
+
+  if (value === '') {
+    return DEFAULT_BASE_HREF;
+  }
+
+  return value.startsWith('/') ? value : `/${value}`;
+}

--- a/packages/nest/angular-ssr/src/lib/core/angular-ssr-registration-runtime.ts
+++ b/packages/nest/angular-ssr/src/lib/core/angular-ssr-registration-runtime.ts
@@ -8,7 +8,11 @@ import {
   ɵsetAngularAppManifest as setAngularAppManifest,
 } from '@angular/ssr';
 
-import type { AngularSsrRegistrationOptions } from './angular-ssr-registration.js';
+import {
+  createAngularSsrRegistration,
+  type AngularSsrRegistrationOptions,
+  type ResolvedAngularSsrRegistrationOptions,
+} from './angular-ssr-registration.js';
 
 const DEFAULT_BASE_HREF = '/';
 const DEFAULT_INLINE_CRITICAL_CSS = false;
@@ -20,19 +24,24 @@ export interface RegisteredAngularSsrApplication {
   cleanup(): void;
 }
 
+export type AngularSsrRegistrationInput =
+  | AngularSsrRegistrationOptions
+  | ResolvedAngularSsrRegistrationOptions;
+
 export async function registerAngularSsrApplication(
-  options: Readonly<AngularSsrRegistrationOptions>,
+  options: Readonly<AngularSsrRegistrationInput>,
 ): Promise<RegisteredAngularSsrApplication> {
-  const requestUrl = createRouteExtractionUrl(options.routeExtractionUrl);
-  const baseHref = normalizeBaseHref(options.baseHref);
+  const registration = await resolveAngularSsrRegistration(options);
+  const requestUrl = createRouteExtractionUrl(registration.routeExtractionUrl);
+  const baseHref = normalizeBaseHref(registration.baseHref);
   const manifest = {
     baseHref,
     assets: {
-      [INDEX_SERVER_DOCUMENT_PATH]: createServerAsset(options.document),
+      [INDEX_SERVER_DOCUMENT_PATH]: createServerAsset(registration.document),
     },
-    bootstrap: options.bootstrap,
+    bootstrap: registration.bootstrap,
     inlineCriticalCss:
-      options.inlineCriticalCss ?? DEFAULT_INLINE_CRITICAL_CSS,
+      registration.inlineCriticalCss ?? DEFAULT_INLINE_CRITICAL_CSS,
   } as const;
   const { routeTree, errors } = await extractRoutesAndCreateRouteTree({
     url: requestUrl,
@@ -59,7 +68,7 @@ export async function registerAngularSsrApplication(
     },
     basePath: baseHref,
     supportedLocales: {},
-    allowedHosts: [...(options.allowedHosts ?? [])],
+    allowedHosts: [...(registration.allowedHosts ?? [])],
   });
 
   return {
@@ -72,8 +81,18 @@ export function resetAngularSsrRegistration(): void {
   destroyAngularServerApp();
 }
 
+async function resolveAngularSsrRegistration(
+  options: Readonly<AngularSsrRegistrationInput>,
+): Promise<ResolvedAngularSsrRegistrationOptions> {
+  if ('document' in options) {
+    return options;
+  }
+
+  return createAngularSsrRegistration(options);
+}
+
 function createRouteExtractionUrl(
-  value: AngularSsrRegistrationOptions['routeExtractionUrl'],
+  value: AngularSsrRegistrationInput['routeExtractionUrl'],
 ): URL {
   if (value instanceof URL) {
     return new URL(value.toString());

--- a/packages/nest/angular-ssr/src/lib/core/angular-ssr-registration.spec.ts
+++ b/packages/nest/angular-ssr/src/lib/core/angular-ssr-registration.spec.ts
@@ -1,0 +1,24 @@
+import type { ApplicationRef } from '@angular/core';
+import type { BootstrapContext } from '@angular/platform-browser';
+import { expectTypeOf, test } from 'vitest';
+
+import type {
+  AngularSsrRegistrationOptions,
+  AngularSsrServerBootstrapLoader,
+} from './angular-ssr-registration.js';
+
+test('exports a public registration contract that consumers can type without Angular private APIs', () => {
+  const registration = {
+    bootstrap: async () => async (_context: BootstrapContext) =>
+      ({}) as ApplicationRef,
+    document: '<!doctype html><html><body><app-root></app-root></body></html>',
+    baseHref: '/',
+    inlineCriticalCss: false,
+    routeExtractionUrl: 'http://localhost/',
+    allowedHosts: ['localhost'],
+  } satisfies AngularSsrRegistrationOptions;
+  const bootstrapLoader: AngularSsrServerBootstrapLoader = registration.bootstrap;
+
+  expectTypeOf(bootstrapLoader).toBeFunction();
+  expectTypeOf(registration).toMatchTypeOf<AngularSsrRegistrationOptions>();
+});

--- a/packages/nest/angular-ssr/src/lib/core/angular-ssr-registration.spec.ts
+++ b/packages/nest/angular-ssr/src/lib/core/angular-ssr-registration.spec.ts
@@ -1,17 +1,23 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
 import type { ApplicationRef } from '@angular/core';
 import type { BootstrapContext } from '@angular/platform-browser';
 import { expectTypeOf, test } from 'vitest';
 
-import type {
+import {
   AngularSsrRegistrationOptions,
   AngularSsrServerBootstrapLoader,
+  createAngularSsrRegistration,
+  type ResolvedAngularSsrRegistrationOptions,
 } from './angular-ssr-registration.js';
 
 test('exports a public registration contract that consumers can type without Angular private APIs', () => {
   const registration = {
     bootstrap: async () => async (_context: BootstrapContext) =>
       ({}) as ApplicationRef,
-    document: '<!doctype html><html><body><app-root></app-root></body></html>',
+    templatePath: '/tmp/index.server.html',
     baseHref: '/',
     inlineCriticalCss: false,
     routeExtractionUrl: 'http://localhost/',
@@ -21,4 +27,57 @@ test('exports a public registration contract that consumers can type without Ang
 
   expectTypeOf(bootstrapLoader).toBeFunction();
   expectTypeOf(registration).toMatchTypeOf<AngularSsrRegistrationOptions>();
+});
+
+test('reads template content into a resolved registration', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'angular-ssr-registration-'));
+  const templatePath = join(directory, 'index.server.html');
+
+  try {
+    await writeFile(
+      templatePath,
+      '<!doctype html><html><body><app-root></app-root></body></html>',
+    );
+
+    const registration = await createAngularSsrRegistration({
+      bootstrap: async () => async (_context: BootstrapContext) =>
+        ({}) as ApplicationRef,
+      templatePath,
+    });
+
+    expectTypeOf(registration).toMatchTypeOf<ResolvedAngularSsrRegistrationOptions>();
+    expect(registration.templatePath).toBe(templatePath);
+    expect(registration.document).toContain('<app-root></app-root>');
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('fails when the template file does not exist', async () => {
+  await expect(
+    createAngularSsrRegistration({
+      bootstrap: async () => async (_context: BootstrapContext) =>
+        ({}) as ApplicationRef,
+      templatePath: join(tmpdir(), 'missing-angular-ssr-template.html'),
+    }),
+  ).rejects.toThrow('Failed to read Angular SSR template');
+});
+
+test('fails when the template path is not a readable file', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'angular-ssr-registration-'));
+  const templatePath = join(directory, 'templates');
+
+  try {
+    await mkdir(templatePath);
+
+    await expect(
+      createAngularSsrRegistration({
+        bootstrap: async () => async (_context: BootstrapContext) =>
+          ({}) as ApplicationRef,
+        templatePath,
+      }),
+    ).rejects.toThrow('Failed to read Angular SSR template');
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });

--- a/packages/nest/angular-ssr/src/lib/core/angular-ssr-registration.ts
+++ b/packages/nest/angular-ssr/src/lib/core/angular-ssr-registration.ts
@@ -1,0 +1,17 @@
+import type { ApplicationRef, Type } from '@angular/core';
+import type { BootstrapContext } from '@angular/platform-browser';
+
+export type AngularSsrServerBootstrap =
+  | Type<unknown>
+  | ((context: BootstrapContext) => Promise<ApplicationRef>);
+
+export type AngularSsrServerBootstrapLoader = () => Promise<AngularSsrServerBootstrap>;
+
+export interface AngularSsrRegistrationOptions {
+  bootstrap: AngularSsrServerBootstrapLoader;
+  document: string;
+  baseHref?: string;
+  inlineCriticalCss?: boolean;
+  routeExtractionUrl?: string | URL;
+  allowedHosts?: readonly string[];
+}

--- a/packages/nest/angular-ssr/src/lib/core/angular-ssr-registration.ts
+++ b/packages/nest/angular-ssr/src/lib/core/angular-ssr-registration.ts
@@ -1,3 +1,6 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
 import type { ApplicationRef, Type } from '@angular/core';
 import type { BootstrapContext } from '@angular/platform-browser';
 
@@ -9,9 +12,40 @@ export type AngularSsrServerBootstrapLoader = () => Promise<AngularSsrServerBoot
 
 export interface AngularSsrRegistrationOptions {
   bootstrap: AngularSsrServerBootstrapLoader;
+  templatePath: string;
+  baseHref?: string;
+  inlineCriticalCss?: boolean;
+  routeExtractionUrl?: string | URL;
+  allowedHosts?: readonly string[];
+}
+
+export interface ResolvedAngularSsrRegistrationOptions {
+  bootstrap: AngularSsrServerBootstrapLoader;
+  templatePath: string;
   document: string;
   baseHref?: string;
   inlineCriticalCss?: boolean;
   routeExtractionUrl?: string | URL;
   allowedHosts?: readonly string[];
+}
+
+export async function createAngularSsrRegistration(
+  options: Readonly<AngularSsrRegistrationOptions>,
+): Promise<ResolvedAngularSsrRegistrationOptions> {
+  const templatePath = resolve(options.templatePath);
+
+  try {
+    return {
+      ...options,
+      templatePath,
+      document: await readFile(templatePath, 'utf8'),
+    };
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Unknown template read error.';
+
+    throw new Error(
+      `Failed to read Angular SSR template from "${templatePath}": ${message}`,
+    );
+  }
 }

--- a/packages/nest/angular-ssr/src/lib/nest/nest-angular-ssr-bootstrap.spec.ts
+++ b/packages/nest/angular-ssr/src/lib/nest/nest-angular-ssr-bootstrap.spec.ts
@@ -5,7 +5,10 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { createAngularSsrRenderer } from '../core/angular-node-ssr-renderer.js';
-import { setupAngularSsrFixture } from '../../testing/angular-ssr-fixture.js';
+import {
+  createAngularSsrFixtureRegistration,
+  setupAngularSsrFixture,
+} from '../../testing/angular-ssr-fixture.js';
 import { createNestFastifyFixture } from '../../testing/nest-fastify-fixture.js';
 import { bootstrapNestAngularSsr } from './nest-angular-ssr-bootstrap.js';
 import type { INestApplication } from '@nestjs/common';
@@ -122,6 +125,50 @@ describe('bootstrapNestAngularSsr', () => {
     expect(result.reply.callNotFound).toHaveBeenCalledTimes(1);
   });
 
+  it('creates the integration from angular registration options', async () => {
+    const browserAssetsDir = await createTempAssetsDir();
+    const app = createMockApp();
+
+    try {
+      const integration = await bootstrapNestAngularSsr(app, {
+        angular: createAngularSsrFixtureRegistration(),
+        routing: { browserAssetsDir },
+      });
+
+      const response = await integration.renderer.render(
+        new Request('http://localhost/'),
+      );
+
+      expect(response?.status).toBe(200);
+      expect(await response?.text()).toContain('SSR Fixture');
+    } finally {
+      await rm(browserAssetsDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects ambiguous configuration when angular and integration renderer are both provided', async () => {
+    const browserAssetsDir = await createTempAssetsDir();
+    const app = createMockApp();
+
+    try {
+      await expect(
+        bootstrapNestAngularSsr(app, {
+          angular: createAngularSsrFixtureRegistration(),
+          integration: {
+            renderer: {
+              render: vi.fn().mockResolvedValue(null),
+            },
+          },
+          routing: { browserAssetsDir },
+        }),
+      ).rejects.toThrow(
+        'Cannot provide both "angular" and "integration.renderer"',
+      );
+    } finally {
+      await rm(browserAssetsDir, { recursive: true, force: true });
+    }
+  });
+
   it('composes the real integration and routing helpers in a real Nest Fastify app', async () => {
     const ssrFixture = await setupAngularSsrFixture();
     const browserAssetsDir = await createTempAssetsDir({
@@ -173,6 +220,53 @@ describe('bootstrapNestAngularSsr', () => {
     } finally {
       await nestFixture.close();
       ssrFixture.cleanup();
+      await rm(browserAssetsDir, { recursive: true, force: true });
+    }
+  });
+
+  it('composes the real routing helpers from the angular registration path in a real Nest Fastify app', async () => {
+    const browserAssetsDir = await createTempAssetsDir({
+      'main.js': 'console.log("asset");',
+    });
+    const nestFixture = await createNestFastifyFixture(async (app, fastify) => {
+      fastify.get('/api/health', async (_request, reply) => {
+        await reply.send('ok');
+      });
+
+      await bootstrapNestAngularSsr(app, {
+        angular: createAngularSsrFixtureRegistration(),
+        routing: {
+          browserAssetsDir,
+          apiPrefix: '/api',
+        },
+      });
+    });
+
+    try {
+      const assetResponse = await nestFixture.inject({
+        method: 'GET',
+        url: '/main.js',
+      });
+      const ssrResponse = await nestFixture.inject({
+        method: 'GET',
+        url: '/',
+        headers: { host: 'localhost' },
+      });
+      const apiResponse = await nestFixture.inject({
+        method: 'GET',
+        url: '/api/health',
+      });
+
+      expect(assetResponse.statusCode).toBe(200);
+      expect(assetResponse.body).toBe('console.log("asset");');
+
+      expect(ssrResponse.statusCode).toBe(200);
+      expect(ssrResponse.body).toContain('SSR Fixture');
+
+      expect(apiResponse.statusCode).toBe(200);
+      expect(apiResponse.body).toBe('ok');
+    } finally {
+      await nestFixture.close();
       await rm(browserAssetsDir, { recursive: true, force: true });
     }
   });

--- a/packages/nest/angular-ssr/src/lib/nest/nest-angular-ssr-bootstrap.ts
+++ b/packages/nest/angular-ssr/src/lib/nest/nest-angular-ssr-bootstrap.ts
@@ -1,5 +1,6 @@
 import type { INestApplication } from '@nestjs/common';
 
+import type { AngularSsrRegistrationOptions } from '../core/angular-ssr-registration.js';
 import {
   createNestAngularSsrIntegration,
   type CreateNestAngularSsrIntegrationOptions,
@@ -11,6 +12,7 @@ import {
 } from './nest-angular-ssr-routing.js';
 
 export interface BootstrapNestAngularSsrOptions<TContext = unknown> {
+  angular?: Readonly<AngularSsrRegistrationOptions>;
   integration?: Readonly<CreateNestAngularSsrIntegrationOptions<TContext>>;
   routing: Readonly<RegisterNestAngularSsrRoutesOptions>;
 }
@@ -21,10 +23,39 @@ export async function bootstrapNestAngularSsr<TContext = unknown>(
 ): Promise<NestAngularSsrIntegration<TContext>> {
   const integration = createNestAngularSsrIntegration<TContext>(
     app,
-    options.integration,
+    resolveIntegrationOptions(options),
   );
 
   await registerNestAngularSsrRoutes(app, integration, options.routing);
 
   return integration;
+}
+
+function resolveIntegrationOptions<TContext>(
+  options: Readonly<BootstrapNestAngularSsrOptions<TContext>>,
+): Readonly<CreateNestAngularSsrIntegrationOptions<TContext>> | undefined {
+  const { angular, integration } = options;
+
+  if (!angular) {
+    return integration;
+  }
+
+  if (integration?.renderer) {
+    throw new Error(
+      'Cannot provide both "angular" and "integration.renderer" to bootstrapNestAngularSsr.',
+    );
+  }
+
+  if (integration?.rendererOptions) {
+    throw new Error(
+      'Cannot provide both "angular" and "integration.rendererOptions" to bootstrapNestAngularSsr.',
+    );
+  }
+
+  return {
+    ...integration,
+    rendererOptions: {
+      registration: angular,
+    },
+  };
 }

--- a/packages/nest/angular-ssr/src/lib/nest/nest-angular-ssr-module.spec.ts
+++ b/packages/nest/angular-ssr/src/lib/nest/nest-angular-ssr-module.spec.ts
@@ -19,7 +19,10 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import { createAngularSsrRenderer } from '../core/angular-node-ssr-renderer.js';
-import { setupAngularSsrFixture } from '../../testing/angular-ssr-fixture.js';
+import {
+  createAngularSsrFixtureRegistration,
+  setupAngularSsrFixture,
+} from '../../testing/angular-ssr-fixture.js';
 import type { BootstrapNestAngularSsrOptions } from './nest-angular-ssr-bootstrap.js';
 import {
   NEST_ANGULAR_SSR_MODULE_OPTIONS,
@@ -53,9 +56,12 @@ describe('NestAngularSsrModule', () => {
 
   it('forRootAsync wires useFactory and inject into the options provider', async () => {
     const dependencyToken = Symbol('dependency');
-    const options = createModuleOptions('/tmp/browser-assets', {
-      apiPrefix: '/api',
-    });
+    const options = {
+      ...createModuleOptions('/tmp/browser-assets', {
+        apiPrefix: '/api',
+      }),
+      angular: createAngularSsrFixtureRegistration(),
+    } satisfies NestAngularSsrModuleOptions;
     const useFactory = vi.fn((...args: unknown[]) => {
       expect(args).toEqual(['/api']);
       return options;
@@ -113,6 +119,27 @@ describe('NestAngularSsrModule', () => {
       expect(firstIntegration).toBe(secondIntegration);
       expect(context.fastify.register).toHaveBeenCalledTimes(1);
       expect(context.fastify.route).toHaveBeenCalledTimes(2);
+    } finally {
+      await rm(browserAssetsDir, { recursive: true, force: true });
+    }
+  });
+
+  it('delegates angular registration through the bootstrap service', async () => {
+    const browserAssetsDir = await createTempAssetsDir();
+    const context = createBootstrapServiceContext({
+      angular: createAngularSsrFixtureRegistration(),
+      routing: { browserAssetsDir },
+    });
+
+    try {
+      const integration = await context.service.getIntegration();
+      const response = await integration.renderer.render(
+        new Request('http://localhost/'),
+      );
+
+      expect(response?.status).toBe(200);
+      expect(await response?.text()).toContain('SSR Fixture');
+      expect(context.fastify.register).toHaveBeenCalledTimes(1);
     } finally {
       await rm(browserAssetsDir, { recursive: true, force: true });
     }
@@ -192,6 +219,58 @@ describe('NestAngularSsrModule', () => {
     } finally {
       await app.close();
       ssrFixture.cleanup();
+      await rm(browserAssetsDir, { recursive: true, force: true });
+    }
+  });
+
+  it('composes the angular registration path in a real Nest Fastify app', async () => {
+    const browserAssetsDir = await createTempAssetsDir({
+      'main.js': 'console.log("asset");',
+    });
+    const app = await createRealModuleFixture({
+      angular: createAngularSsrFixtureRegistration(),
+      routing: {
+        browserAssetsDir,
+        apiPrefix: '/api',
+      },
+    });
+
+    try {
+      const fastify = app.getHttpAdapter().getInstance() as unknown as {
+        inject(options: {
+          method: string;
+          url: string;
+          headers?: Record<string, string>;
+        }): Promise<{ statusCode: number; body: string }>;
+        ready(): Promise<void>;
+      };
+
+      await fastify.ready();
+
+      const assetResponse = await fastify.inject({
+        method: 'GET',
+        url: '/main.js',
+      });
+      const ssrResponse = await fastify.inject({
+        method: 'GET',
+        url: '/',
+        headers: { host: 'localhost' },
+      });
+      const apiResponse = await fastify.inject({
+        method: 'GET',
+        url: '/api/health',
+      });
+
+      expect(assetResponse.statusCode).toBe(200);
+      expect(assetResponse.body).toBe('console.log("asset");');
+
+      expect(ssrResponse.statusCode).toBe(200);
+      expect(ssrResponse.body).toContain('SSR Fixture');
+
+      expect(apiResponse.statusCode).toBe(200);
+      expect(apiResponse.body).toBe('ok');
+    } finally {
+      await app.close();
       await rm(browserAssetsDir, { recursive: true, force: true });
     }
   });

--- a/packages/nest/angular-ssr/src/testing/angular-ssr-fixture.ts
+++ b/packages/nest/angular-ssr/src/testing/angular-ssr-fixture.ts
@@ -1,5 +1,3 @@
-import { createHash } from 'node:crypto';
-
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import {
   bootstrapApplication,
@@ -11,12 +9,13 @@ import {
   provideServerRendering,
   type ServerRoute,
   withRoutes,
-  ɵdestroyAngularServerApp,
-  ɵextractRoutesAndCreateRouteTree,
-  ɵgetOrCreateAngularServerApp,
-  ɵsetAngularAppEngineManifest,
-  ɵsetAngularAppManifest,
 } from '@angular/ssr';
+
+import type { AngularSsrRegistrationOptions } from '../lib/core/angular-ssr-registration.js';
+import {
+  registerAngularSsrApplication,
+  resetAngularSsrRegistration,
+} from '../lib/core/angular-ssr-registration-runtime.js';
 
 const FIXTURE_URL = 'http://localhost/';
 const INDEX_SERVER_HTML = `<!doctype html>
@@ -53,14 +52,6 @@ const serverRoutes: ServerRoute[] = [
   { path: '', renderMode: RenderMode.Server },
 ];
 
-function createServerAsset(text: string) {
-  return {
-    text: async () => text,
-    hash: createHash('sha256').update(text).digest('hex'),
-    size: Buffer.byteLength(text),
-  };
-}
-
 async function bootstrapFixtureApplication(context: BootstrapContext) {
   return bootstrapApplication(
     FixtureAppComponent,
@@ -74,48 +65,31 @@ async function bootstrapFixtureApplication(context: BootstrapContext) {
   );
 }
 
-export async function setupAngularSsrFixture(url = FIXTURE_URL) {
-  const manifest = {
-    baseHref: '/',
-    assets: {
-      'index.server.html': createServerAsset(INDEX_SERVER_HTML),
-    },
+export function createAngularSsrFixtureRegistration(
+  url = FIXTURE_URL,
+): AngularSsrRegistrationOptions {
+  return {
     bootstrap: async () => bootstrapFixtureApplication,
+    document: INDEX_SERVER_HTML,
     inlineCriticalCss: false,
-  } as const;
-
-  const { routeTree, errors } = await ɵextractRoutesAndCreateRouteTree({
-    url: new URL(url),
-    manifest,
-  });
-
-  if (errors.length > 0) {
-    throw new Error(
-      `Angular SSR fixture route extraction failed:\n${errors.join('\n')}`,
-    );
-  }
-
-  ɵdestroyAngularServerApp();
-  ɵsetAngularAppManifest({
-    ...manifest,
-    routes: routeTree.toObject(),
-  });
-  ɵsetAngularAppEngineManifest({
-    entryPoints: {
-      '': async () => ({
-        ɵgetOrCreateAngularServerApp,
-        ɵdestroyAngularServerApp,
-      }),
-    },
-    basePath: '/',
-    supportedLocales: {},
+    routeExtractionUrl: url,
     allowedHosts: ['localhost'],
-  });
+  };
+}
+
+export async function setupAngularSsrFixture(url = FIXTURE_URL) {
+  const registration = createAngularSsrFixtureRegistration(url);
+  const fixture = await registerAngularSsrApplication(registration);
 
   return {
-    requestUrl: url,
+    registration,
+    requestUrl: fixture.requestUrl,
     cleanup() {
-      ɵdestroyAngularServerApp();
+      fixture.cleanup();
     },
   };
+}
+
+export function cleanupAngularSsrFixture(): void {
+  resetAngularSsrRegistration();
 }

--- a/packages/nest/angular-ssr/src/testing/angular-ssr-fixture.ts
+++ b/packages/nest/angular-ssr/src/testing/angular-ssr-fixture.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import {
   bootstrapApplication,
@@ -18,16 +20,9 @@ import {
 } from '../lib/core/angular-ssr-registration-runtime.js';
 
 const FIXTURE_URL = 'http://localhost/';
-const INDEX_SERVER_HTML = `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>Angular SSR Fixture</title>
-  </head>
-  <body>
-    <app-root></app-root>
-  </body>
-</html>`;
+const FIXTURE_TEMPLATE_PATH = fileURLToPath(
+  new URL('./index.server.html', import.meta.url),
+);
 
 const FixtureAppComponent = Component({
   selector: 'app-root',
@@ -70,7 +65,7 @@ export function createAngularSsrFixtureRegistration(
 ): AngularSsrRegistrationOptions {
   return {
     bootstrap: async () => bootstrapFixtureApplication,
-    document: INDEX_SERVER_HTML,
+    templatePath: FIXTURE_TEMPLATE_PATH,
     inlineCriticalCss: false,
     routeExtractionUrl: url,
     allowedHosts: ['localhost'],

--- a/packages/nest/angular-ssr/src/testing/index.server.html
+++ b/packages/nest/angular-ssr/src/testing/index.server.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Angular SSR Fixture</title>
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>


### PR DESCRIPTION
Add a public Angular SSR registration contract and internalize manifest and server-app wiring behind the package boundary. Thread the new `angular` option through the Nest bootstrap/module APIs, migrate the CJS/ESM consumer fixtures to the public path, and update docs and validation coverage to match the new integration story.

Closes #79 Closes #80 Closes #81 Closes #82 Closes #83 Closes #84