### PR TITLE
feat(skills): add repo-local ai skills

### DIFF
--- a/skills/community-docs-and-examples/SKILL.md
+++ b/skills/community-docs-and-examples/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: community-docs-and-examples
+description: implement and refine documentation, examples, and package-facing guidance in anarchitecture-community. use when work belongs specifically in the community adapters repo, especially for package readmes, docs/examples, validation notes, public api explanation, adoption guidance, and keeping extracted community packages clear, minimal, and easy to consume.
+---
+
+# Overview
+Use this skill when the task belongs in `anarchitecture-community` and is primarily about docs, examples, public package guidance, or example/validation surfaces.
+
+Before changing content, inspect these repo files when relevant:
+
+- `README.md`
+- package-level `README.md` files
+- docs under `docs/`
+- validation or example docs tied to the affected package
+
+## Core implementation rules
+- Keep public APIs small and explicit.
+- Prefer framework adapters over framework leakage.
+- Keep examples as validation surfaces, not product packages.
+- Explain both easy mode and advanced mode when the package supports both.
+- Keep package documentation as the source of truth for package behavior.
+
+## Required workflow
+1. Identify the affected package or docs area under `packages/` or `docs/`.
+2. Determine whether the task is package docs, example docs, validation docs, or public adoption guidance.
+3. Make the smallest change that improves clarity without overstating guarantees.
+4. Preserve the repo’s stance that community packages are reusable integrations, not core domain bricks.
+5. Summarize the updated audience, package surface, and any follow-up validation needed.
+
+## Output expectations
+In the final summary, explicitly report:
+- affected package or docs area
+- whether package behavior, examples, or only documentation changed
+- whether the docs now describe easy mode, advanced mode, and boundaries clearly

--- a/skills/community-docs-and-examples/agents/openai.yaml
+++ b/skills/community-docs-and-examples/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: Community Docs and Examples
+  short_description: Improve package docs, examples, and public guidance in the community adapters repo.

--- a/skills/monitor-ci/SKILL.md
+++ b/skills/monitor-ci/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: monitor-ci
+description: troubleshoot ci, workflow, build, test, lint, package validation, docs, example, or release failures in anarchitecture-community. use when a github action, nx target, package build, example validation flow, or release process fails and the task is specifically about diagnosing and fixing that repo while preserving clear public package boundaries and explicit community adapter behavior.
+---
+
+# Overview
+Use this skill when CI or automation is failing in `anarchitecture-community`.
+
+Inspect these sources first when relevant:
+
+- workflow logs and failed job output
+- `README.md`
+- affected package `README.md`
+- relevant docs or validation notes under `docs/`
+
+## Required workflow
+1. Identify the failing workflow, job, package, and Nx target.
+2. Reduce the failure to the smallest reproducible command.
+3. Fix the root cause while preserving the repo’s public-package and adapter boundaries.
+4. Validate with package-manager-prefixed Nx commands.
+5. Summarize the root cause, fix, validation, and any package-surface implications.
+
+## Repo-specific checks
+- Do not paper over failures by broadening public APIs unnecessarily.
+- Keep examples as validation surfaces, not product packages.
+- If a fix changes published package behavior, say whether docs and examples also need updates.

--- a/skills/monitor-ci/agents/openai.yaml
+++ b/skills/monitor-ci/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: Community Monitor CI
+  short_description: Diagnose and fix CI, Nx, docs, example, and release failures in the community repo.


### PR DESCRIPTION
## Summary

Add repo-local AI skills to `anarchitecture-community`.

## Added skills

- `skills/community-docs-and-examples`
- `skills/monitor-ci`

## Notes

These skills are repo-local and do not assume an MCP server exists yet.
They are intended to guide docs/examples work and CI troubleshooting specifically for the community repo.
