### PR TITLE
init(governance-core): Extract portable extension contracts and runtime into Governance Core

### DIFF
--- a/packages/governance/core/README.md
+++ b/packages/governance/core/README.md
@@ -1,18 +1,22 @@
 # `@anarchitects/governance-core`
 
-Platform-independent Governance Core contracts and deterministic logic owned by `anarchitects/anarchitecture-community`.
+Platform-independent Governance Core contracts, deterministic logic, and portable extension APIs owned by `anarchitects/anarchitecture-community`.
 
 This package is part of the Governance split and now owns the extracted Core public API from `anarchitects/anarchitecture-plugins/packages/governance/src/core`.
+It also owns the portable Governance extension contracts and runtime registry from `anarchitects/anarchitecture-plugins/packages/governance/src/extensions`.
 
 Public entrypoint:
 
 ```ts
 import {
+  DefaultGovernanceCapabilityRegistry,
   buildGovernanceAssessment,
+  collectGovernanceSignals,
   buildMetricSnapshot,
   compareSnapshots,
   coreBuiltInRulePack,
   evaluateRulePack,
+  registerLoadedGovernanceExtensions,
   normalizeGovernanceException,
   normalizeGovernanceProfile,
 } from '@anarchitects/governance-core';
@@ -21,8 +25,23 @@ import {
 Current migration status:
 
 - Core contracts and deterministic logic are extracted here.
+- Portable extension contracts, capability contracts, diagnostics, and runtime registration are extracted here.
 - Nx-specific Governance integration remains in `anarchitects/anarchitecture-plugins`.
-- Portable extension contracts are deferred to the dedicated follow-up slice.
+- Nx-specific extension discovery, config loading, module loading, and plugin probing remain in `anarchitects/anarchitecture-plugins`.
+
+Portable extension API ownership:
+
+- `src/extensions/contracts.ts` owns extension registration and execution contracts.
+- `src/extensions/capabilities.ts` owns the generic capability registry.
+- `src/extensions/diagnostics.ts` owns extension diagnostic contracts.
+- `src/extensions/runtime.ts` owns deterministic runtime registration and execution helpers.
+- host-owned discovery, config loading, filesystem traversal, and module resolution stay out of this package.
+
+`workspaceRoot` decision:
+
+- `GovernanceExtensionHostContext.workspaceRoot` remains `string`.
+- Rationale: it is a generic workspace concept, not an Nx runtime API.
+- Core only carries that value in the portable host context; it does not read files, inspect `nx.json`, or perform module loading from it.
 
 This package must remain platform-independent:
 

--- a/packages/governance/core/package.json
+++ b/packages/governance/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@anarchitects/governance-core",
   "version": "0.0.1",
-  "description": "Platform-independent Governance Core contracts and deterministic logic for the Community repository.",
+  "description": "Platform-independent Governance Core contracts, deterministic logic, and portable extension APIs for the Community repository.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/governance/core/src/extensions/boundaries.spec.ts
+++ b/packages/governance/core/src/extensions/boundaries.spec.ts
@@ -1,0 +1,60 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+describe('Extension boundary guardrail', () => {
+  it('keeps extracted extension APIs free of Nx, host loading, and plugin imports', () => {
+    const extensionsRoot = fileURLToPath(new URL('.', import.meta.url));
+    const forbiddenPatterns = [
+      /from ['"]nx['"]/,
+      /from ['"]@nx\//,
+      /from ['"]\.\.\/nx-host(?:\/|['"])/,
+      /from ['"]\.\.\/plugin(?:\/|['"])/,
+      /from ['"]\.\.\/executors(?:\/|['"])/,
+      /from ['"]\.\.\/generators(?:\/|['"])/,
+      /from ['"]\.\.\/standalone-cli(?:\/|['"])/,
+      /from ['"]\.\.\/typescript-adapter(?:\/|['"])/,
+      /from ['"]\.\.\/manual-workspace(?:\/|['"])/,
+      /from ['"]\.\.\/nx-adapter(?:\/|['"])/,
+      /from ['"]\.\.\/conformance-adapter(?:\/|['"])/,
+      /from ['"]node:fs['"]/,
+      /from ['"]node:path['"]/,
+      /readFileSync\(/,
+      /import\(specifier\)/,
+      /anarchitecture-plugins/,
+    ];
+
+    for (const filePath of collectImplementationFiles(extensionsRoot)) {
+      const source = readFileSync(filePath, 'utf8');
+
+      for (const pattern of forbiddenPatterns) {
+        expect(source).not.toMatch(pattern);
+      }
+    }
+  });
+});
+
+function collectImplementationFiles(directory: string): string[] {
+  const collected: string[] = [];
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const resolved = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      collected.push(...collectImplementationFiles(resolved));
+      continue;
+    }
+
+    if (
+      entry.isFile() &&
+      entry.name.endsWith('.ts') &&
+      !entry.name.endsWith('.spec.ts') &&
+      !entry.name.endsWith('.test.ts') &&
+      !entry.name.endsWith('.fixtures.ts')
+    ) {
+      collected.push(resolved);
+    }
+  }
+
+  return collected.sort((left, right) => left.localeCompare(right));
+}

--- a/packages/governance/core/src/extensions/capabilities.spec.ts
+++ b/packages/governance/core/src/extensions/capabilities.spec.ts
@@ -1,0 +1,76 @@
+import { DefaultGovernanceCapabilityRegistry } from './capabilities.js';
+import type { GovernanceCapability } from '../core/index.js';
+
+describe('DefaultGovernanceCapabilityRegistry', () => {
+  const capabilities: GovernanceCapability[] = [
+    {
+      id: 'capability:nx',
+    },
+    {
+      id: 'capability:ownership',
+      version: '1',
+      data: {
+        source: 'codeowners',
+      },
+    },
+  ];
+
+  it('stores capabilities and returns them by id', () => {
+    const registry = new DefaultGovernanceCapabilityRegistry(capabilities);
+
+    expect(registry.get('capability:nx')).toEqual({
+      id: 'capability:nx',
+    });
+    expect(registry.get<{ source: string }>('capability:ownership')).toEqual({
+      id: 'capability:ownership',
+      version: '1',
+      data: {
+        source: 'codeowners',
+      },
+    });
+  });
+
+  it('reports capability presence through has()', () => {
+    const registry = new DefaultGovernanceCapabilityRegistry(capabilities);
+
+    expect(registry.has('capability:nx')).toBe(true);
+    expect(registry.has('capability:missing')).toBe(false);
+  });
+
+  it('lists capabilities in insertion order', () => {
+    const registry = new DefaultGovernanceCapabilityRegistry(capabilities);
+
+    expect(registry.list()).toEqual(capabilities);
+  });
+
+  it('returns a defensive copy from list()', () => {
+    const registry = new DefaultGovernanceCapabilityRegistry(capabilities);
+    const listed = registry.list();
+
+    listed.pop();
+
+    expect(registry.list()).toEqual(capabilities);
+  });
+
+  it('returns frozen capability entries from list()', () => {
+    const registry = new DefaultGovernanceCapabilityRegistry(capabilities);
+    const [firstCapability] = registry.list();
+
+    expect(Object.isFrozen(firstCapability)).toBe(true);
+  });
+
+  it('rejects duplicate capability ids', () => {
+    expect(
+      () =>
+        new DefaultGovernanceCapabilityRegistry([
+          {
+            id: 'capability:nx',
+          },
+          {
+            id: 'capability:nx',
+            version: '2',
+          },
+        ]),
+    ).toThrow('Duplicate governance capability id "capability:nx"');
+  });
+});

--- a/packages/governance/core/src/extensions/capabilities.ts
+++ b/packages/governance/core/src/extensions/capabilities.ts
@@ -1,0 +1,46 @@
+import type { GovernanceCapability } from '../core/index.js';
+
+export interface GovernanceCapabilityRegistry {
+  has(id: string): boolean;
+  get<TData = unknown>(id: string): GovernanceCapability<TData> | undefined;
+  list(): GovernanceCapability[];
+}
+
+export class DefaultGovernanceCapabilityRegistry
+  implements GovernanceCapabilityRegistry
+{
+  private readonly capabilitiesById = new Map<string, GovernanceCapability>();
+  private readonly capabilities: readonly GovernanceCapability[];
+
+  constructor(capabilities: readonly GovernanceCapability[]) {
+    const normalizedCapabilities = capabilities.map((capability) =>
+      Object.freeze({ ...capability }),
+    );
+
+    for (const capability of normalizedCapabilities) {
+      if (this.capabilitiesById.has(capability.id)) {
+        throw new Error(
+          `Duplicate governance capability id "${capability.id}" is not allowed.`,
+        );
+      }
+
+      this.capabilitiesById.set(capability.id, capability);
+    }
+
+    this.capabilities = Object.freeze([...normalizedCapabilities]);
+  }
+
+  has(id: string): boolean {
+    return this.capabilitiesById.has(id);
+  }
+
+  get<TData = unknown>(id: string): GovernanceCapability<TData> | undefined {
+    return this.capabilitiesById.get(id) as
+      | GovernanceCapability<TData>
+      | undefined;
+  }
+
+  list(): GovernanceCapability[] {
+    return [...this.capabilities];
+  }
+}

--- a/packages/governance/core/src/extensions/contracts.ts
+++ b/packages/governance/core/src/extensions/contracts.ts
@@ -1,0 +1,77 @@
+import type {
+  GovernanceProfile,
+  GovernanceWorkspace,
+  Measurement,
+  Violation,
+} from '../core/index.js';
+import type { GovernanceSignal } from '../core/signals.js';
+import type { GovernanceCapabilityRegistry } from './capabilities.js';
+
+export interface GovernanceExtensionHostContext {
+  // Kept as a portable host-provided string. Core does not read from the
+  // filesystem or assume Nx semantics; it only carries the workspace root.
+  workspaceRoot: string;
+  profileName: string;
+  options: Readonly<Record<string, unknown>>;
+  inventory: GovernanceWorkspace;
+  capabilities: GovernanceCapabilityRegistry;
+}
+
+export interface GovernanceExtensionDefinition {
+  id: string;
+  register(host: GovernanceExtensionHost): void | Promise<void>;
+}
+
+export interface GovernanceExtensionHost {
+  readonly context: GovernanceExtensionHostContext;
+  registerEnricher(enricher: GovernanceWorkspaceEnricher): void;
+  registerRulePack(rulePack: GovernanceExtensionRulePack): void;
+  registerSignalProvider(signalProvider: GovernanceSignalProvider): void;
+  registerMetricProvider(metricProvider: GovernanceMetricProvider): void;
+}
+
+export interface GovernanceExtensionExecutionInput {
+  workspace: GovernanceWorkspace;
+  profile: GovernanceProfile;
+  context: GovernanceExtensionHostContext;
+}
+
+export type GovernanceWorkspaceEnricherInput =
+  GovernanceExtensionExecutionInput;
+
+export type GovernanceRulePackInput = GovernanceExtensionExecutionInput;
+
+export interface GovernanceSignalProviderInput
+  extends GovernanceExtensionExecutionInput {
+  violations: Violation[];
+  signals: GovernanceSignal[];
+}
+
+export interface GovernanceMetricProviderInput
+  extends GovernanceExtensionExecutionInput {
+  signals: GovernanceSignal[];
+  measurements: Measurement[];
+  violations: Violation[];
+}
+
+export interface GovernanceWorkspaceEnricher {
+  enrichWorkspace(
+    input: GovernanceWorkspaceEnricherInput,
+  ): GovernanceWorkspace | Promise<GovernanceWorkspace>;
+}
+
+export interface GovernanceExtensionRulePack {
+  evaluate(input: GovernanceRulePackInput): Violation[] | Promise<Violation[]>;
+}
+
+export interface GovernanceSignalProvider {
+  provideSignals(
+    input: GovernanceSignalProviderInput,
+  ): GovernanceSignal[] | Promise<GovernanceSignal[]>;
+}
+
+export interface GovernanceMetricProvider {
+  provideMetrics(
+    input: GovernanceMetricProviderInput,
+  ): Measurement[] | Promise<Measurement[]>;
+}

--- a/packages/governance/core/src/extensions/diagnostics.ts
+++ b/packages/governance/core/src/extensions/diagnostics.ts
@@ -1,0 +1,24 @@
+export type GovernanceExtensionDiagnosticSeverity =
+  | 'notice'
+  | 'warning'
+  | 'error';
+
+export type GovernanceExtensionDiagnosticCode =
+  | 'governance.extension.loaded'
+  | 'governance.extension.skipped_optional_missing'
+  | 'governance.extension.missing_required'
+  | 'governance.extension.invalid_definition'
+  | 'governance.extension.duplicate_id'
+  | 'governance.extension.registration_failed'
+  | 'governance.extension.legacy_probing_used'
+  | 'governance.extension.legacy_entrypoint_missing';
+
+export interface GovernanceExtensionDiagnostic {
+  code: GovernanceExtensionDiagnosticCode;
+  severity: GovernanceExtensionDiagnosticSeverity;
+  message: string;
+  packageName?: string;
+  moduleSpecifier?: string;
+  extensionId?: string;
+  legacy?: boolean;
+}

--- a/packages/governance/core/src/extensions/index.ts
+++ b/packages/governance/core/src/extensions/index.ts
@@ -1,0 +1,16 @@
+export * from './capabilities.js';
+export * from './contracts.js';
+export * from './diagnostics.js';
+export {
+  GovernanceExtensionRegistrationError,
+  applyGovernanceEnrichers,
+  collectGovernanceMeasurements,
+  collectGovernanceSignals,
+  evaluateGovernanceRulePacks,
+  registerLoadedGovernanceExtensions,
+  registerLoadedGovernanceExtensionsWithDiagnostics,
+  type GovernanceExtensionRegistrationResult,
+  type GovernanceExtensionRegistry,
+  type GovernanceLoadedExtension,
+  type RegisterLoadedGovernanceExtensionsOptions,
+} from './runtime.js';

--- a/packages/governance/core/src/extensions/runtime.spec.ts
+++ b/packages/governance/core/src/extensions/runtime.spec.ts
@@ -1,0 +1,238 @@
+import {
+  DefaultGovernanceCapabilityRegistry,
+  type GovernanceProfile,
+  type GovernanceExtensionHostContext,
+} from '../index.js';
+import {
+  GovernanceExtensionRegistrationError,
+  type GovernanceLoadedExtension,
+  collectGovernanceMeasurements,
+  collectGovernanceSignals,
+  registerLoadedGovernanceExtensions,
+  registerLoadedGovernanceExtensionsWithDiagnostics,
+} from './runtime.js';
+
+describe('governance extension runtime', () => {
+  const baseContext: GovernanceExtensionHostContext = {
+    workspaceRoot: '/repo',
+    profileName: 'frontend-layered',
+    options: {
+      output: 'cli',
+      reportType: 'health',
+    },
+    inventory: {
+      id: 'workspace',
+      name: 'workspace',
+      root: '/repo',
+      projects: [],
+      dependencies: [],
+    },
+    capabilities: new DefaultGovernanceCapabilityRegistry([
+      {
+        id: 'capability:nx',
+      },
+    ]),
+  };
+
+  const baseProfile: GovernanceProfile = {
+    name: 'frontend-layered',
+    boundaryPolicySource: 'profile',
+    layers: [],
+    allowedDomainDependencies: {},
+    ownership: {
+      required: false,
+      metadataField: 'ownership',
+    },
+    health: {
+      statusThresholds: {
+        goodMinScore: 85,
+        warningMinScore: 70,
+      },
+    },
+    metrics: {},
+  };
+
+  function createLoadedExtension(
+    id: string,
+    register: GovernanceLoadedExtension['definition']['register'] = () =>
+      undefined,
+    overrides: Partial<GovernanceLoadedExtension> = {},
+  ): GovernanceLoadedExtension {
+    return {
+      sourceSpecifier: `@anarchitects/${id}`,
+      moduleSpecifier: `@anarchitects/${id}`,
+      legacy: false,
+      definition: {
+        id,
+        register,
+      },
+      ...overrides,
+    };
+  }
+
+  it('registers normalized loaded extensions in input order without module loading', async () => {
+    const registrationOrder: string[] = [];
+
+    const registry = await registerLoadedGovernanceExtensions(baseContext, [
+      createLoadedExtension('plugin-a', (host) => {
+        registrationOrder.push('plugin-a');
+        host.registerSignalProvider({
+          provideSignals: async () => [],
+        });
+      }),
+      createLoadedExtension('plugin-b', (host) => {
+        registrationOrder.push('plugin-b');
+        host.registerMetricProvider({
+          provideMetrics: async () => [],
+        });
+      }),
+    ]);
+
+    expect(registrationOrder).toEqual(['plugin-a', 'plugin-b']);
+    expect(registry.signalProviders.map((entry) => entry.pluginId)).toEqual([
+      'plugin-a',
+    ]);
+    expect(registry.metricProviders.map((entry) => entry.pluginId)).toEqual([
+      'plugin-b',
+    ]);
+  });
+
+  it('passes immutable runtime context to loaded extensions', async () => {
+    let receivedContext: GovernanceExtensionHostContext | undefined;
+
+    await registerLoadedGovernanceExtensions(baseContext, [
+      createLoadedExtension('plugin-a', (host) => {
+        receivedContext = host.context;
+      }),
+    ]);
+
+    expect(receivedContext).toEqual(baseContext);
+    expect(Object.isFrozen(receivedContext)).toBe(true);
+    expect(Object.isFrozen(receivedContext?.options)).toBe(true);
+  });
+
+  it('preserves precomputed loader diagnostics during runtime registration', async () => {
+    const result = await registerLoadedGovernanceExtensionsWithDiagnostics(
+      baseContext,
+      [createLoadedExtension('plugin-a')],
+      {
+        diagnostics: [
+          {
+            code: 'governance.extension.loaded',
+            severity: 'notice',
+            message:
+              'Loaded governance extension from "@anarchitects/plugin-a".',
+            packageName: '@anarchitects/plugin-a',
+            moduleSpecifier: '@anarchitects/plugin-a',
+            extensionId: 'plugin-a',
+            legacy: false,
+          },
+        ],
+      },
+    );
+
+    expect(result.diagnostics).toEqual([
+      {
+        code: 'governance.extension.loaded',
+        severity: 'notice',
+        message: 'Loaded governance extension from "@anarchitects/plugin-a".',
+        packageName: '@anarchitects/plugin-a',
+        moduleSpecifier: '@anarchitects/plugin-a',
+        extensionId: 'plugin-a',
+        legacy: false,
+      },
+    ]);
+  });
+
+  it('emits deterministic duplicate-id diagnostics for normalized loaded extensions', async () => {
+    await expect(
+      registerLoadedGovernanceExtensionsWithDiagnostics(baseContext, [
+        createLoadedExtension('shared-extension', () => undefined, {
+          sourceSpecifier: '@anarchitects/plugin-a',
+          moduleSpecifier: '@anarchitects/plugin-a',
+        }),
+        createLoadedExtension('shared-extension', () => undefined, {
+          sourceSpecifier: '@anarchitects/plugin-b',
+          moduleSpecifier: '@anarchitects/plugin-b',
+        }),
+      ]),
+    ).rejects.toEqual(
+      expect.objectContaining<Partial<GovernanceExtensionRegistrationError>>({
+        diagnostics: [
+          {
+            code: 'governance.extension.duplicate_id',
+            severity: 'error',
+            message:
+              'Duplicate governance extension id "shared-extension" was found in "@anarchitects/plugin-a" and "@anarchitects/plugin-b".',
+            packageName: '@anarchitects/plugin-b',
+            moduleSpecifier: '@anarchitects/plugin-b',
+            extensionId: 'shared-extension',
+            legacy: false,
+          },
+        ],
+      }),
+    );
+  });
+
+  it('applies runtime-added sourcePluginId metadata to signals and measurements', async () => {
+    const registry = await registerLoadedGovernanceExtensions(baseContext, [
+      createLoadedExtension('plugin-a', (host) => {
+        host.registerSignalProvider({
+          provideSignals: async () => [
+            {
+              id: 'signal-a',
+              type: 'ownership-gap',
+              source: 'policy',
+              severity: 'warning',
+              category: 'ownership',
+              message: 'Ownership gap',
+              relatedProjectIds: ['project-a'],
+              createdAt: '2026-05-21T00:00:00.000Z',
+            },
+          ],
+        });
+        host.registerMetricProvider({
+          provideMetrics: async () => [
+            {
+              id: 'metric-a',
+              name: 'Metric A',
+              family: 'ownership',
+              value: 0.5,
+              score: 50,
+              maxScore: 100,
+              unit: 'ratio',
+            },
+          ],
+        });
+      }),
+    ]);
+
+    const signals = await collectGovernanceSignals(registry, {
+      workspace: baseContext.inventory,
+      profile: baseProfile,
+      context: baseContext,
+      violations: [],
+      signals: [],
+    });
+    const measurements = await collectGovernanceMeasurements(registry, {
+      workspace: baseContext.inventory,
+      profile: baseProfile,
+      context: baseContext,
+      signals,
+      measurements: [],
+      violations: [],
+    });
+
+    expect(signals).toEqual([
+      expect.objectContaining({
+        source: 'extension',
+        sourcePluginId: 'plugin-a',
+      }),
+    ]);
+    expect(measurements).toEqual([
+      expect.objectContaining({
+        sourcePluginId: 'plugin-a',
+      }),
+    ]);
+  });
+});

--- a/packages/governance/core/src/extensions/runtime.ts
+++ b/packages/governance/core/src/extensions/runtime.ts
@@ -1,0 +1,308 @@
+import type {
+  GovernanceWorkspace,
+  Measurement,
+  Violation,
+} from '../core/index.js';
+import type { GovernanceSignal } from '../core/signals.js';
+import type {
+  GovernanceExtensionDefinition,
+  GovernanceExtensionHost as GovernanceExtensionHostContract,
+  GovernanceExtensionHostContext,
+  GovernanceMetricProvider,
+  GovernanceMetricProviderInput,
+  GovernanceExtensionRulePack,
+  GovernanceRulePackInput,
+  GovernanceSignalProvider,
+  GovernanceSignalProviderInput,
+  GovernanceWorkspaceEnricher,
+  GovernanceWorkspaceEnricherInput,
+} from './contracts.js';
+import type { GovernanceExtensionDiagnostic } from './diagnostics.js';
+
+interface RegisteredGovernanceContribution<T> {
+  pluginId: string;
+  contribution: T;
+}
+
+export interface GovernanceExtensionRegistry {
+  metricProviders: RegisteredGovernanceContribution<GovernanceMetricProvider>[];
+  signalProviders: RegisteredGovernanceContribution<GovernanceSignalProvider>[];
+  rulePacks: RegisteredGovernanceContribution<GovernanceExtensionRulePack>[];
+  enrichers: RegisteredGovernanceContribution<GovernanceWorkspaceEnricher>[];
+}
+
+export interface GovernanceLoadedExtension {
+  sourceSpecifier: string;
+  moduleSpecifier: string;
+  legacy?: boolean;
+  definition: GovernanceExtensionDefinition;
+}
+
+export interface RegisterLoadedGovernanceExtensionsOptions {
+  diagnostics?: readonly GovernanceExtensionDiagnostic[];
+}
+
+export interface GovernanceExtensionRegistrationResult {
+  registry: GovernanceExtensionRegistry;
+  diagnostics: GovernanceExtensionDiagnostic[];
+}
+
+export class GovernanceExtensionRegistrationError extends Error {
+  readonly diagnostics: GovernanceExtensionDiagnostic[];
+
+  constructor(message: string, diagnostics: GovernanceExtensionDiagnostic[]) {
+    super(message);
+    this.name = 'GovernanceExtensionRegistrationError';
+    this.diagnostics = diagnostics;
+  }
+}
+
+export class GovernanceExtensionHost
+  implements GovernanceExtensionHostContract
+{
+  readonly context: GovernanceExtensionHostContext;
+
+  private readonly registry: GovernanceExtensionRegistry = {
+    metricProviders: [],
+    signalProviders: [],
+    rulePacks: [],
+    enrichers: [],
+  };
+
+  private readonly pluginId: string;
+
+  constructor(context: GovernanceExtensionHostContext, pluginId: string) {
+    this.context = Object.freeze({
+      ...context,
+      options: Object.freeze({ ...context.options }),
+    });
+    this.pluginId = pluginId;
+  }
+
+  registerMetricProvider(metricProvider: GovernanceMetricProvider): void {
+    this.registry.metricProviders.push({
+      pluginId: this.pluginId,
+      contribution: metricProvider,
+    });
+  }
+
+  registerSignalProvider(signalProvider: GovernanceSignalProvider): void {
+    this.registry.signalProviders.push({
+      pluginId: this.pluginId,
+      contribution: signalProvider,
+    });
+  }
+
+  registerRulePack(rulePack: GovernanceExtensionRulePack): void {
+    this.registry.rulePacks.push({
+      pluginId: this.pluginId,
+      contribution: rulePack,
+    });
+  }
+
+  registerEnricher(enricher: GovernanceWorkspaceEnricher): void {
+    this.registry.enrichers.push({
+      pluginId: this.pluginId,
+      contribution: enricher,
+    });
+  }
+
+  toRegistry(): GovernanceExtensionRegistry {
+    return {
+      metricProviders: [...this.registry.metricProviders],
+      signalProviders: [...this.registry.signalProviders],
+      rulePacks: [...this.registry.rulePacks],
+      enrichers: [...this.registry.enrichers],
+    };
+  }
+}
+
+export async function registerLoadedGovernanceExtensions(
+  context: GovernanceExtensionHostContext,
+  extensions: readonly GovernanceLoadedExtension[],
+): Promise<GovernanceExtensionRegistry> {
+  const result = await registerLoadedGovernanceExtensionsWithDiagnostics(
+    context,
+    extensions,
+  );
+  return result.registry;
+}
+
+export async function registerLoadedGovernanceExtensionsWithDiagnostics(
+  context: GovernanceExtensionHostContext,
+  extensions: readonly GovernanceLoadedExtension[],
+  options: RegisterLoadedGovernanceExtensionsOptions = {},
+): Promise<GovernanceExtensionRegistrationResult> {
+  const registry: GovernanceExtensionRegistry = {
+    metricProviders: [],
+    signalProviders: [],
+    rulePacks: [],
+    enrichers: [],
+  };
+  const diagnostics = [...(options.diagnostics ?? [])];
+  const seenExtensionIds = new Map<string, string>();
+
+  for (const extension of extensions) {
+    try {
+      validateGovernanceExtensionId(extension);
+    } catch (error) {
+      diagnostics.push({
+        code: 'governance.extension.invalid_definition',
+        severity: 'error',
+        message: toErrorMessage(error),
+        packageName: extension.sourceSpecifier,
+        moduleSpecifier: extension.moduleSpecifier,
+        legacy: extension.legacy,
+      });
+      throw new GovernanceExtensionRegistrationError(
+        toErrorMessage(error),
+        diagnostics,
+      );
+    }
+
+    const previousModule = seenExtensionIds.get(extension.definition.id);
+    if (previousModule) {
+      const message = `Duplicate governance extension id "${extension.definition.id}" was found in "${previousModule}" and "${extension.moduleSpecifier}".`;
+      diagnostics.push({
+        code: 'governance.extension.duplicate_id',
+        severity: 'error',
+        message,
+        packageName: extension.sourceSpecifier,
+        moduleSpecifier: extension.moduleSpecifier,
+        extensionId: extension.definition.id,
+        legacy: extension.legacy,
+      });
+      throw new GovernanceExtensionRegistrationError(message, diagnostics);
+    }
+
+    seenExtensionIds.set(extension.definition.id, extension.moduleSpecifier);
+
+    try {
+      const host = new GovernanceExtensionHost(
+        context,
+        extension.definition.id,
+      );
+      await extension.definition.register(host);
+      mergeRegistry(registry, host.toRegistry());
+    } catch (error) {
+      const message = `Governance extension "${
+        extension.definition.id
+      }" from "${
+        extension.moduleSpecifier
+      }" failed during registration: ${toErrorMessage(error)}`;
+      diagnostics.push({
+        code: 'governance.extension.registration_failed',
+        severity: 'error',
+        message,
+        packageName: extension.sourceSpecifier,
+        moduleSpecifier: extension.moduleSpecifier,
+        extensionId: extension.definition.id,
+        legacy: extension.legacy,
+      });
+      throw new GovernanceExtensionRegistrationError(message, diagnostics);
+    }
+  }
+
+  return {
+    registry,
+    diagnostics,
+  };
+}
+
+export async function applyGovernanceEnrichers(
+  registry: GovernanceExtensionRegistry,
+  input: GovernanceWorkspaceEnricherInput,
+): Promise<GovernanceWorkspace> {
+  let workspace = input.workspace;
+
+  for (const enricher of registry.enrichers) {
+    const enrichedWorkspace = await enricher.contribution.enrichWorkspace({
+      ...input,
+      workspace,
+    });
+    workspace = enrichedWorkspace;
+  }
+
+  return workspace;
+}
+
+export async function evaluateGovernanceRulePacks(
+  registry: GovernanceExtensionRegistry,
+  input: GovernanceRulePackInput,
+): Promise<Violation[]> {
+  const violations = await Promise.all(
+    registry.rulePacks.map(async (rulePack) => {
+      const providedViolations = await rulePack.contribution.evaluate(input);
+      return providedViolations.map((violation) => ({
+        ...violation,
+        sourcePluginId: violation.sourcePluginId ?? rulePack.pluginId,
+      }));
+    }),
+  );
+
+  return violations.flat();
+}
+
+export async function collectGovernanceSignals(
+  registry: GovernanceExtensionRegistry,
+  input: GovernanceSignalProviderInput,
+): Promise<GovernanceSignal[]> {
+  const signals = await Promise.all(
+    registry.signalProviders.map(async (signalProvider) => {
+      const providedSignals =
+        await signalProvider.contribution.provideSignals(input);
+      return providedSignals.map((signal) => ({
+        ...signal,
+        source: 'extension' as const,
+        sourcePluginId: signal.sourcePluginId ?? signalProvider.pluginId,
+      }));
+    }),
+  );
+
+  return signals.flat();
+}
+
+export async function collectGovernanceMeasurements(
+  registry: GovernanceExtensionRegistry,
+  input: GovernanceMetricProviderInput,
+): Promise<Measurement[]> {
+  const measurements = await Promise.all(
+    registry.metricProviders.map(async (metricProvider) => {
+      const providedMeasurements =
+        await metricProvider.contribution.provideMetrics(input);
+      return providedMeasurements.map((measurement) => ({
+        ...measurement,
+        sourcePluginId: measurement.sourcePluginId ?? metricProvider.pluginId,
+      }));
+    }),
+  );
+
+  return measurements.flat();
+}
+
+function mergeRegistry(
+  target: GovernanceExtensionRegistry,
+  source: GovernanceExtensionRegistry,
+): void {
+  target.metricProviders.push(...source.metricProviders);
+  target.signalProviders.push(...source.signalProviders);
+  target.rulePacks.push(...source.rulePacks);
+  target.enrichers.push(...source.enrichers);
+}
+
+function validateGovernanceExtensionId(
+  extension: GovernanceLoadedExtension,
+): void {
+  if (
+    typeof extension.definition.id !== 'string' ||
+    extension.definition.id.trim().length === 0
+  ) {
+    throw new Error(
+      `Governance extension module "${extension.moduleSpecifier}" must declare a non-empty "id".`,
+    );
+  }
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/governance/core/src/index.ts
+++ b/packages/governance/core/src/index.ts
@@ -1,1 +1,2 @@
 export * from './core/index.js';
+export * from './extensions/index.js';


### PR DESCRIPTION
closes #104
