### PR TITLE
init(governance-core,governance-cli,governance-adapter-typescript): Re-run package release checks against ADR boundaries

### DIFF
--- a/packages/governance/adapter-typescript/README.md
+++ b/packages/governance/adapter-typescript/README.md
@@ -45,6 +45,7 @@ The public package surface is intentionally adapter-oriented:
 ```ts
 import {
   buildTypeScriptImportGraph,
+  createGovernanceWorkspaceAdapter,
   createTypeScriptWorkspaceAdapter,
   detectTypeScriptWorkspace,
   discoverTypeScriptProjects,
@@ -63,6 +64,7 @@ import {
 The root export currently includes:
 
 - `createTypeScriptWorkspaceAdapter(...)`
+- `createGovernanceWorkspaceAdapter(...)`
 - `detectTypeScriptWorkspace(...)`
 - `parsePackageManagerWorkspace(...)`
 - `parseTsConfigResolution(...)`

--- a/packages/governance/adapter-typescript/src/workspace-adapter.spec.ts
+++ b/packages/governance/adapter-typescript/src/workspace-adapter.spec.ts
@@ -92,6 +92,18 @@ describe('generic Governance adapter exports', () => {
     );
     expect(typedDefault.id).toBe('governance-adapter:typescript');
   });
+
+  it('implements the optional Core-owned probe contract', () => {
+    const adapter = createGovernanceWorkspaceAdapter();
+
+    expect(adapter.probe).toBeTypeOf('function');
+
+    const result = adapter.probe?.(materializeFixture('pnpm'));
+    expect(result).toMatchObject({
+      supported: true,
+      confidence: 'high',
+    });
+  });
 });
 
 const specDir = fileURLToPath(new URL('.', import.meta.url));

--- a/packages/governance/adapter-typescript/src/workspace-adapter.ts
+++ b/packages/governance/adapter-typescript/src/workspace-adapter.ts
@@ -3,9 +3,11 @@ import path from 'node:path';
 
 import type {
   GovernanceWorkspaceAdapter,
+  GovernanceWorkspaceAdapterProbeResult,
   GovernanceWorkspaceAdapterResult,
 } from '@anarchitects/governance-core';
 
+import { detectTypeScriptWorkspace } from './detect-typescript-workspace.js';
 import { buildTypeScriptImportGraph } from './import-graph.js';
 import { mapTypeScriptImportsToGovernanceDependencies } from './map-imports-to-projects.js';
 import { parsePackageManagerWorkspace } from './parse-package-manager-workspace.js';
@@ -45,6 +47,24 @@ export function createTypeScriptWorkspaceAdapter(
 ): GovernanceWorkspaceAdapter<string> {
   return {
     id: options.adapterId ?? 'governance-adapter:typescript',
+    probe(workspacePath: string): GovernanceWorkspaceAdapterProbeResult {
+      const detection = detectTypeScriptWorkspace(workspacePath);
+
+      return {
+        supported: detection.supported,
+        confidence: detection.supported
+          ? detection.status === 'supported'
+            ? 'high'
+            : 'low'
+          : 'none',
+        reasons: buildProbeReasons(detection),
+        diagnostics: detection.diagnostics,
+        metadata: {
+          status: detection.status,
+          indicators: detection.indicators,
+        },
+      };
+    },
     loadWorkspace(workspacePath: string): GovernanceWorkspaceAdapterResult {
       const workspaceRoot = path.resolve(workspacePath);
       const workspace = parsePackageManagerWorkspace(workspaceRoot);
@@ -99,6 +119,34 @@ export function createGovernanceWorkspaceAdapter(
 export const governanceWorkspaceAdapter = createGovernanceWorkspaceAdapter();
 
 export default governanceWorkspaceAdapter;
+
+function buildProbeReasons(
+  detection: ReturnType<typeof detectTypeScriptWorkspace>,
+): string[] {
+  const reasons: string[] = [];
+
+  if (detection.indicators.pnpmWorkspace) {
+    reasons.push('pnpm-workspace.yaml is present');
+  }
+
+  if (detection.indicators.packageManagerWorkspaces) {
+    reasons.push('package.json declares package-manager workspaces');
+  }
+
+  if (detection.indicators.tsconfig) {
+    reasons.push('tsconfig.json is present');
+  }
+
+  if (detection.indicators.tsconfigBase) {
+    reasons.push('tsconfig.base.json is present');
+  }
+
+  if (reasons.length === 0) {
+    reasons.push('no TypeScript workspace indicators were found');
+  }
+
+  return reasons;
+}
 
 function inferWorkspaceId(workspaceRoot: string): string {
   return inferWorkspaceName(workspaceRoot);

--- a/packages/governance/cli/README.md
+++ b/packages/governance/cli/README.md
@@ -1,46 +1,24 @@
 # `@anarchitects/governance-cli`
 
 Standalone Governance CLI and runtime host for running Governance checks outside Nx.
-Standalone Governance CLI and host/runtime APIs for running Governance checks outside Nx.
-Standalone Governance CLI and runtime host for running Governance checks outside Nx.
 
 ## Overview
 
-`@anarchitects/governance-cli` provides the executable `agov` command and the programmatic host/runtime APIs for Community-owned Governance packages.
+`@anarchitects/governance-cli` provides the packaged `agov` executable and the programmatic host APIs for running Governance checks against canonical workspace documents or dynamically loaded adapters.
 
-It orchestrates Governance checks through `@anarchitects/governance-core`, supports canonical workspace input documents, and can load compatible adapters dynamically without taking a static dependency on concrete adapter packages.
-`@anarchitects/governance-cli` provides the standalone host surface for Community-owned Governance packages. It supports both the packaged `agov` executable and the exported runtime APIs for programmatic hosts.
-`@anarchitects/governance-cli` provides the executable `agov` command and the programmatic host/runtime APIs for Community-owned Governance packages.
-
-It orchestrates Governance checks through `@anarchitects/governance-core`, supports canonical workspace input documents, and can load compatible adapters dynamically without taking a static dependency on concrete adapter packages.
+The package depends on `@anarchitects/governance-core` and stays adapter-agnostic. Concrete adapters are loaded by package name and validated against Core-owned contracts at runtime.
 
 ## Responsibilities
 
 This package is responsible for:
 
-- exposing the `agov` executable command surface
-- parsing CLI arguments
-- resolving config, profile, workspace, adapter, root, and format options
-- loading standalone profile and canonical workspace documents
-- dynamically loading compatible Governance adapters by package name
-- mapping runtime outcomes to stable exit codes
+- exposing the `agov` command surface
+- parsing arguments and resolving option precedence
+- loading config, profile, and canonical workspace inputs
+- discovering generic adapter candidates from config or package metadata
+- dynamically loading adapter packages and selecting them through Core-owned probe contracts
 - rendering table, markdown, text, and JSON output
-- loading explicit standalone Governance profile documents
-- loading explicit manual Governance workspace documents
-- resolving CLI options from flags, config files, and conventions
-- loading compatible Governance adapters dynamically by package name
-- resolving CLI options from flags, config files, and conventions
-- loading compatible Governance adapters dynamically by package name
-- orchestrating Governance evaluation through `@anarchitects/governance-core`
-- returning a structured Governance check result from the public API
-- keeping argv parsing, exit handling, and report rendering as host concerns
-- exposing the `agov` executable command surface
-- parsing CLI arguments
-- resolving config, profile, workspace, adapter, root, and format options
-- loading standalone profile and canonical workspace documents
-- dynamically loading compatible Governance adapters by package name
 - mapping runtime outcomes to stable exit codes
-- rendering table, markdown, text, and JSON output
 
 This package is not responsible for:
 
@@ -73,7 +51,7 @@ The root export currently includes:
 - `AgovCheckWithAdapterOptions`
 - `AgovCheckWithWorkspacePathOptions`
 
-The executable host implementation and argv handling remain internal package modules.
+The executable command parser and runtime host internals remain internal modules.
 
 ## Executable Usage
 
@@ -92,7 +70,7 @@ The CLI resolves values in this order:
 - explicit flags
 - config file
 - conventional file discovery
-- adapter discovery and probing
+- generic adapter candidate discovery and probe-based selection
 - error with guidance
 
 ## Runtime Modes
@@ -102,6 +80,7 @@ The standalone host currently supports:
 - canonical workspace documents in `.json`, `.yaml`, or `.yml`
 - standalone profile documents in `.json`
 - explicit adapter mode through `--adapter <package> --root <path>`
+- generic adapter candidate discovery through config or package metadata
 - output formats `table`, `markdown`, and `json`
 - `text` as a compatibility alias for `table`
 
@@ -119,56 +98,16 @@ console.log(result.success);
 console.log(result.assessment.health.status);
 ```
 
-The current standalone host flow supports:
-
-- manual workspace documents in `.json`, `.yaml`, or `.yml`
-- standalone profile documents in `.json`
-- report rendering formats `table`, `markdown`, and `json`
-- `text` as a compatibility alias for `table`
-- report rendering formats `table`, `markdown`, and `json`
-- `text` as a compatibility alias for `table`
-
 ## Adapter Model
 
-The intended consumer model for this package is adapter-agnostic:
-
-- the CLI/runtime host should depend on `@anarchitects/governance-core`
-- concrete adapters should implement Core-owned contracts
-- concrete adapters should be supplied, registered, injected, or resolved through Core-owned abstractions
-- adding a future adapter should not require changing this package’s public contract
-
-That is the model package consumers should follow.
-
-## Binary Packaging
-
-This package publishes an `agov` executable through `package.json#bin`.
 `@anarchitects/governance-cli` is adapter-agnostic.
 
-Current command surface:
+That means:
 
-- `agov --help`
-- `agov --version`
-- `agov check`
-- `agov check --workspace <path> --profile <path>`
-- `agov check --adapter <package> --root <path> --profile <path>`
-
-The CLI resolves options in this order:
-
-- explicit flags
-- config file
-- conventional file discovery or adapter inference
-- error with guidance
-
-Supported output formats:
-
-- `table`
-- `markdown`
-- `json`
-- `text` as a compatibility alias for `table`
 - the package depends on `@anarchitects/governance-core`, not on concrete adapter packages
 - concrete adapters implement Core-owned contracts
 - adapters may be injected, discovered, or dynamically loaded by package name
-- adding a future adapter must not require changing the CLI package dependency graph
+- future adapters must not require CLI package dependency changes
 
 If you want to use a concrete adapter such as `@anarchitects/governance-adapter-typescript`, that adapter must be installed separately in the consuming workspace.
 
@@ -178,13 +117,9 @@ For detailed package-boundary rules and adapter-loading expectations, see
 ## Package Boundaries
 
 `@anarchitects/governance-cli` is a standalone runtime host.
-`@anarchitects/governance-cli` is a standalone runtime host.
 
 It should:
 
-- orchestrate Core-owned contracts
-- own command behavior, configuration, and output
-- remain reusable outside Nx
 - orchestrate Core-owned contracts
 - own command behavior, configuration, and output
 - remain reusable outside Nx
@@ -194,13 +129,9 @@ It should not:
 - become the home of canonical Governance contracts
 - statically import concrete adapter packages
 - own adapter-specific detection heuristics
-- statically import concrete adapter packages
-- own adapter-specific detection heuristics
 - take on Nx-only responsibilities
 
 ## Related Packages
 
-- `@anarchitects/governance-core` owns canonical Governance contracts and deterministic evaluation logic
-- `@anarchitects/governance-adapter-typescript` is a sibling concrete adapter package for TypeScript workspace discovery
 - `@anarchitects/governance-core` owns canonical Governance contracts and deterministic evaluation logic
 - `@anarchitects/governance-adapter-typescript` is a sibling concrete adapter package for TypeScript workspace discovery

--- a/packages/governance/cli/src/agov.spec.ts
+++ b/packages/governance/cli/src/agov.spec.ts
@@ -102,6 +102,54 @@ describe('agov executable command surface', () => {
     expect(io.err).toBe('');
   });
 
+  it('discovers adapter candidates from config.adapters and selects a supported adapter by probe', async () => {
+    const io = createMemoryIo();
+    const cwd = createTempWorkspaceRoot('agov-config-adapters-');
+
+    writeFixtureProfile(path.join(cwd, 'profile.json'));
+    writeJson(path.join(cwd, 'agov.config.json'), {
+      profile: './profile.json',
+      adapters: ['adapter-one', 'adapter-two'],
+      format: 'json',
+    });
+
+    expect(
+      await runAgovCli(
+        ['check'],
+        io,
+        undefined,
+        createEnvironment({
+          cwd,
+          moduleLoader: async (specifier: string) => {
+            if (specifier === 'adapter-one') {
+              return createProbeableAdapterModule({
+                workspaceName: 'unsupported-workspace',
+                supported: false,
+                confidence: 'low',
+              });
+            }
+
+            return createProbeableAdapterModule({
+              workspaceName: 'config-selected-workspace',
+              supported: true,
+              confidence: 'high',
+            });
+          },
+        }),
+      ),
+    ).toBe(AGOV_EXIT_SUCCESS);
+    expect(JSON.parse(io.out)).toMatchObject({
+      command: 'check',
+      success: true,
+      assessment: {
+        workspace: {
+          name: 'config-selected-workspace',
+        },
+      },
+    });
+    expect(io.err).toBe('');
+  });
+
   it('uses an explicit config file path and resolves relative config values from the config directory', async () => {
     const io = createMemoryIo();
     const cwd = createTempWorkspaceRoot('agov-explicit-config-');
@@ -286,9 +334,12 @@ describe('agov executable command surface', () => {
     expect(io.err).toBe('');
   });
 
-  it('infers the TypeScript adapter from workspace indicators when no workspace file is present', async () => {
+  it('discovers a compatible adapter from generic package metadata and probe results', async () => {
     const io = createMemoryIo();
-    const cwd = createTypeScriptWorkspaceFixture('agov-ts-inference-');
+    const cwd = createAdapterDiscoveryFixture('agov-adapter-discovery-', [
+      'adapter-one',
+      'adapter-two',
+    ]);
 
     writeFixtureProfile(path.join(cwd, 'governance.profile.json'));
 
@@ -299,10 +350,21 @@ describe('agov executable command surface', () => {
         undefined,
         createEnvironment({
           cwd,
-          moduleLoader: async () =>
-            createAdapterModule({
-              workspaceName: '@fixture/root',
-            }),
+          moduleLoader: async (specifier: string) => {
+            if (specifier === 'adapter-one') {
+              return createProbeableAdapterModule({
+                workspaceName: 'unsupported-workspace',
+                supported: false,
+                confidence: 'low',
+              });
+            }
+
+            return createProbeableAdapterModule({
+              workspaceName: 'supported-workspace',
+              supported: true,
+              confidence: 'high',
+            });
+          },
         }),
       ),
     ).toBe(AGOV_EXIT_SUCCESS);
@@ -311,17 +373,18 @@ describe('agov executable command surface', () => {
       success: true,
       assessment: {
         workspace: {
-          name: '@fixture/root',
+          name: 'supported-workspace',
         },
       },
     });
     expect(io.err).toBe('');
   });
 
-  it('fails clearly when an inferred adapter package cannot be resolved', async () => {
+  it('fails clearly when discovered adapter candidates cannot be loaded or do not support the workspace', async () => {
     const io = createMemoryIo();
-    const cwd = createTypeScriptWorkspaceFixture(
-      'agov-missing-inferred-adapter-',
+    const cwd = createAdapterDiscoveryFixture(
+      'agov-missing-discovered-adapter-',
+      ['adapter-one', 'adapter-two'],
     );
 
     writeFixtureProfile(path.join(cwd, 'governance.profile.json'));
@@ -333,8 +396,16 @@ describe('agov executable command surface', () => {
         undefined,
         createEnvironment({
           cwd,
-          moduleLoader: async () => {
-            throw new Error('not found');
+          moduleLoader: async (specifier: string) => {
+            if (specifier === 'adapter-one') {
+              throw new Error('not found');
+            }
+
+            return createProbeableAdapterModule({
+              workspaceName: 'unsupported-workspace',
+              supported: false,
+              confidence: 'low',
+            });
           },
         }),
       ),
@@ -343,19 +414,25 @@ describe('agov executable command surface', () => {
 
     expect(parsedError).toMatchObject({
       error: {
-        code: 'agov.cli.adapter_not_found',
+        code: 'agov.cli.no_supported_adapter',
         details: {
-          adapter: '@anarchitects/governance-adapter-typescript',
-          inferredBecause: expect.arrayContaining([
-            expect.stringContaining('tsconfig'),
+          attemptedPackages: ['adapter-one', 'adapter-two'],
+          attempts: expect.arrayContaining([
+            expect.objectContaining({
+              packageName: 'adapter-one',
+              status: 'load-failed',
+            }),
+            expect.objectContaining({
+              packageName: 'adapter-two',
+              status: 'unsupported',
+            }),
           ]),
         },
       },
     });
     expect(parsedError.error.message).toContain(
-      'Install "@anarchitects/governance-adapter-typescript"',
+      'Could not find a supported Governance adapter',
     );
-    expect(parsedError.error.message).toContain('--workspace <path>');
   });
 
   it('fails clearly when an explicit adapter package cannot be resolved', async () => {
@@ -594,39 +671,52 @@ function createAdapterModule(input: { workspaceName: string }): unknown {
   };
 }
 
-function createTypeScriptWorkspaceFixture(prefix: string): string {
+function createProbeableAdapterModule(input: {
+  workspaceName: string;
+  supported: boolean;
+  confidence?: 'none' | 'low' | 'medium' | 'high';
+}): unknown {
+  return {
+    createGovernanceWorkspaceAdapter() {
+      return {
+        id: `adapter:${input.workspaceName}`,
+        probe() {
+          return {
+            supported: input.supported,
+            confidence: input.confidence ?? 'none',
+            reasons: input.supported
+              ? ['supported by probe']
+              : ['unsupported by probe'],
+          };
+        },
+        loadWorkspace() {
+          return {
+            workspaceId: input.workspaceName,
+            workspaceName: input.workspaceName,
+            workspaceRoot: '.',
+            projects: [],
+            dependencies: [],
+            diagnostics: [],
+          };
+        },
+      };
+    },
+  };
+}
+
+function createAdapterDiscoveryFixture(
+  prefix: string,
+  adapters: string[],
+): string {
   const root = createTempWorkspaceRoot(prefix);
 
   writeJson(path.join(root, 'package.json'), {
     name: '@fixture/root',
     private: true,
-    workspaces: ['packages/*'],
-    devDependencies: {
-      typescript: '^5.0.0',
+    agov: {
+      adapters,
     },
   });
-  writeJson(path.join(root, 'tsconfig.json'), {
-    compilerOptions: {
-      baseUrl: '.',
-    },
-  });
-
-  writeJson(path.join(root, 'packages/customer/package.json'), {
-    name: '@fixture/customer',
-    version: '0.0.0',
-  });
-  writeJson(path.join(root, 'packages/order/package.json'), {
-    name: '@fixture/order',
-    version: '0.0.0',
-  });
-  writeText(
-    path.join(root, 'packages/customer/src/index.ts'),
-    'export const customer = "customer";\n',
-  );
-  writeText(
-    path.join(root, 'packages/order/src/index.ts'),
-    'export const order = "order";\n',
-  );
 
   return root;
 }

--- a/packages/governance/cli/src/agov.ts
+++ b/packages/governance/cli/src/agov.ts
@@ -1,15 +1,11 @@
-import {
-  existsSync,
-  readFileSync,
-  readdirSync,
-  statSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type {
   GovernanceWorkspaceAdapter,
+  GovernanceWorkspaceAdapterProbeConfidence,
+  GovernanceWorkspaceAdapterProbeResult,
   Violation,
 } from '@anarchitects/governance-core';
 
@@ -63,6 +59,7 @@ export interface AgovCliRuntime {
 export interface AgovCliConfig {
   profile?: string;
   adapter?: string;
+  adapters?: string[];
   root?: string;
   workspace?: string;
   format?: string;
@@ -88,13 +85,10 @@ export interface AgovResolvedCheckCommand {
   format: AgovOutputFormat;
   outputPath?: string;
   configPath?: string;
-  mode: 'workspace' | 'adapter';
+  mode: 'workspace' | 'adapter' | 'adapter-discovery';
   workspacePath?: string;
   adapterPackage?: string;
-  adapterInference?: {
-    packageName: string;
-    reasons: string[];
-  };
+  adapterCandidates?: string[];
 }
 
 export const AGOV_EXIT_SUCCESS = 0;
@@ -142,6 +136,7 @@ export class AgovCliRuntimeError extends Error {
     public readonly code:
       | 'agov.cli.adapter_not_found'
       | 'agov.cli.adapter_contract_mismatch'
+      | 'agov.cli.no_supported_adapter'
       | 'agov.cli.unhandled_error',
     public readonly details?: Record<string, unknown>,
   ) {
@@ -410,13 +405,13 @@ export function resolveAgovCheckCommand(
   const configBasePath = configPath ? path.dirname(configPath) : cwd;
 
   if (
-    config.adapter &&
+    (config.adapter || readNonEmptyStringArray(config.adapters).length > 0) &&
     config.workspace &&
     !options.adapterPackage &&
     !options.workspacePath
   ) {
     throw new AgovCliUsageError(
-      'Config file cannot define both "adapter" and "workspace" for agov check. Pass one mode only, or override explicitly with CLI flags.',
+      'Config file cannot define both adapter-mode and workspace-mode inputs for agov check. Pass one mode only, or override explicitly with CLI flags.',
       'agov.cli.invalid_config',
     );
   }
@@ -432,16 +427,26 @@ export function resolveAgovCheckCommand(
     explicitRootPath ??
     resolveConfigRelativePath(config.root, configBasePath) ??
     cwd;
+  const explicitWorkspacePath = resolveExplicitPath(options.workspacePath, cwd);
+  const configuredWorkspacePath = resolveConfigRelativePath(
+    config.workspace,
+    configBasePath,
+  );
+  const conventionalWorkspacePath = resolveConventionalFile(
+    rootPath,
+    AGOV_WORKSPACE_FILE_NAMES,
+  );
   const workspacePath =
-    resolveExplicitPath(options.workspacePath, cwd) ??
-    resolveConfigRelativePath(config.workspace, configBasePath) ??
-    resolveConventionalFile(rootPath, AGOV_WORKSPACE_FILE_NAMES);
+    explicitWorkspacePath ??
+    configuredWorkspacePath ??
+    conventionalWorkspacePath;
   const profilePath =
     resolveExplicitPath(options.profilePath, cwd) ??
     resolveConfigRelativePath(config.profile, configBasePath) ??
     resolveConventionalFile(rootPath, AGOV_PROFILE_FILE_NAMES);
   const adapterPackage =
     options.adapterPackage ?? readNonEmptyString(config.adapter);
+  const adapterCandidates = resolveAdapterCandidatePackages(rootPath, config);
   const format = resolveOutputFormat(options.format, config.format);
   const outputPath = resolveExplicitPath(options.outputPath, cwd);
 
@@ -452,7 +457,7 @@ export function resolveAgovCheckCommand(
     );
   }
 
-  if (workspacePath && !options.adapterPackage && !config.adapter) {
+  if (explicitWorkspacePath || configuredWorkspacePath) {
     return {
       command: 'check',
       rootPath,
@@ -478,19 +483,16 @@ export function resolveAgovCheckCommand(
     };
   }
 
-  const adapterInference = inferAdapterPackage(rootPath);
-
-  if (adapterInference) {
+  if (adapterCandidates.length > 0) {
     return {
       command: 'check',
       rootPath,
       profilePath,
-      adapterPackage: adapterInference.packageName,
-      adapterInference,
+      adapterCandidates,
       format,
       ...(outputPath ? { outputPath } : {}),
       ...(configPath ? { configPath } : {}),
-      mode: 'adapter',
+      mode: 'adapter-discovery',
     };
   }
 
@@ -508,7 +510,7 @@ export function resolveAgovCheckCommand(
   }
 
   throw new AgovCliUsageError(
-    'Could not resolve Governance workspace input. Pass "--workspace <path>" for canonical workspace mode, or "--adapter <package> --root <path>" for adapter mode.',
+    'Could not resolve Governance workspace input. Pass "--workspace <path>" for canonical workspace mode, pass "--adapter <package> --root <path>" for explicit adapter mode, or configure generic adapter candidates.',
     'agov.cli.missing_workspace_or_adapter',
   );
 }
@@ -532,17 +534,30 @@ async function resolveAgovCheckRuntimeOptions(
   }
 
   if (!command.adapterPackage) {
-    throw new AgovCliRuntimeError(
-      'Resolved adapter mode without an adapter package.',
-      'agov.cli.unhandled_error',
+    if (command.mode !== 'adapter-discovery' || !command.adapterCandidates) {
+      throw new AgovCliRuntimeError(
+        'Resolved adapter mode without an adapter package.',
+        'agov.cli.unhandled_error',
+      );
+    }
+
+    const resolvedAdapter = await discoverGovernanceWorkspaceAdapter(
+      command.adapterCandidates,
+      command.rootPath,
+      environment,
     );
+
+    return {
+      profilePath: command.profilePath,
+      workspaceAdapter: resolvedAdapter.adapter,
+      workspaceAdapterInput: command.rootPath,
+    };
   }
 
   const workspaceAdapter = await loadGovernanceWorkspaceAdapter(
     command.adapterPackage,
     command.rootPath,
     environment,
-    command.adapterInference,
   );
 
   return {
@@ -556,10 +571,6 @@ async function loadGovernanceWorkspaceAdapter(
   packageName: string,
   rootPath: string,
   environment: Pick<AgovCliEnvironment, 'moduleLoader'>,
-  inference?: {
-    packageName: string;
-    reasons: string[];
-  },
 ): Promise<GovernanceWorkspaceAdapter<string>> {
   let loadedModule: unknown;
 
@@ -567,12 +578,11 @@ async function loadGovernanceWorkspaceAdapter(
     loadedModule = await environment.moduleLoader(packageName);
   } catch {
     throw new AgovCliRuntimeError(
-      renderMissingAdapterMessage(packageName, rootPath, inference),
+      renderMissingAdapterMessage(packageName),
       'agov.cli.adapter_not_found',
       {
         adapter: packageName,
         rootPath,
-        ...(inference ? { inferredBecause: inference.reasons } : {}),
       },
     );
   }
@@ -591,6 +601,85 @@ async function loadGovernanceWorkspaceAdapter(
   }
 
   return resolvedAdapter;
+}
+
+async function discoverGovernanceWorkspaceAdapter(
+  packageNames: string[],
+  rootPath: string,
+  environment: Pick<AgovCliEnvironment, 'moduleLoader'>,
+): Promise<{
+  adapter: GovernanceWorkspaceAdapter<string>;
+  packageName: string;
+  probe: GovernanceWorkspaceAdapterProbeResult;
+}> {
+  const attempts: Array<Record<string, unknown>> = [];
+  let bestMatch:
+    | {
+        adapter: GovernanceWorkspaceAdapter<string>;
+        packageName: string;
+        probe: GovernanceWorkspaceAdapterProbeResult;
+        rank: number;
+      }
+    | undefined;
+
+  for (const packageName of packageNames) {
+    let loadedModule: unknown;
+
+    try {
+      loadedModule = await environment.moduleLoader(packageName);
+    } catch {
+      attempts.push({ packageName, status: 'load-failed' });
+      continue;
+    }
+
+    const adapter = resolveAdapterExport(loadedModule);
+
+    if (!adapter) {
+      attempts.push({ packageName, status: 'contract-mismatch' });
+      continue;
+    }
+
+    if (typeof adapter.probe !== 'function') {
+      attempts.push({ packageName, status: 'missing-probe' });
+      continue;
+    }
+
+    const probe = adapter.probe(rootPath);
+    attempts.push({
+      packageName,
+      status: probe.supported ? 'supported' : 'unsupported',
+      confidence: probe.confidence ?? 'none',
+      reasons: probe.reasons ?? [],
+    });
+
+    if (!probe.supported) {
+      continue;
+    }
+
+    const rank = rankProbeConfidence(probe.confidence);
+    if (!bestMatch || rank > bestMatch.rank) {
+      bestMatch = {
+        adapter,
+        packageName,
+        probe,
+        rank,
+      };
+    }
+  }
+
+  if (!bestMatch) {
+    throw new AgovCliRuntimeError(
+      'Could not find a supported Governance adapter from the discovered candidate packages.',
+      'agov.cli.no_supported_adapter',
+      {
+        rootPath,
+        attemptedPackages: packageNames,
+        attempts,
+      },
+    );
+  }
+
+  return bestMatch;
 }
 
 function resolveAdapterExport(
@@ -635,25 +724,8 @@ function isGovernanceWorkspaceAdapter(
   );
 }
 
-function renderMissingAdapterMessage(
-  packageName: string,
-  rootPath: string,
-  inference:
-    | {
-        packageName: string;
-        reasons: string[];
-      }
-    | undefined,
-): string {
+function renderMissingAdapterMessage(packageName: string): string {
   const lines = [`Could not load Governance adapter package "${packageName}".`];
-
-  if (inference) {
-    lines.push(
-      `The adapter was inferred for "${rootPath}" because ${inference.reasons.join(
-        ', ',
-      )}.`,
-    );
-  }
 
   lines.push(
     `Install "${packageName}" in the consuming workspace to use adapter mode.`,
@@ -663,6 +735,21 @@ function renderMissingAdapterMessage(
   );
 
   return lines.join(' ');
+}
+
+function rankProbeConfidence(
+  confidence: GovernanceWorkspaceAdapterProbeConfidence | undefined,
+): number {
+  switch (confidence) {
+    case 'high':
+      return 3;
+    case 'medium':
+      return 2;
+    case 'low':
+      return 1;
+    default:
+      return 0;
+  }
 }
 
 function resolveConfigPath(
@@ -771,6 +858,15 @@ function readNonEmptyString(value: unknown): string | undefined {
     : undefined;
 }
 
+function readNonEmptyStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value
+        .filter((entry): entry is string => typeof entry === 'string')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0)
+    : [];
+}
+
 function resolveConventionalFile(
   rootPath: string,
   fileNames: readonly string[],
@@ -786,101 +882,56 @@ function resolveConventionalFile(
   return undefined;
 }
 
-function inferAdapterPackage(rootPath: string):
-  | {
-      packageName: string;
-      reasons: string[];
-    }
-  | undefined {
-  const reasons: string[] = [];
+function resolveAdapterCandidatePackages(
+  rootPath: string,
+  config: AgovCliConfig,
+): string[] {
+  return [
+    ...new Set([
+      ...readNonEmptyStringArray(config.adapters),
+      ...resolvePackageJsonAdapterCandidates(rootPath),
+    ]),
+  ];
+}
 
-  if (existsSync(path.join(rootPath, 'tsconfig.json'))) {
-    reasons.push('tsconfig.json is present');
-  }
-
-  if (existsSync(path.join(rootPath, 'tsconfig.base.json'))) {
-    reasons.push('tsconfig.base.json is present');
-  }
-
+function resolvePackageJsonAdapterCandidates(rootPath: string): string[] {
   const packageJsonPath = path.join(rootPath, 'package.json');
-  if (existsSync(packageJsonPath)) {
-    try {
-      const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
-        dependencies?: Record<string, string>;
-        devDependencies?: Record<string, string>;
-        peerDependencies?: Record<string, string>;
-        workspaces?: unknown;
-      };
 
-      const dependencyNames = [
-        ...Object.keys(parsed.dependencies ?? {}),
-        ...Object.keys(parsed.devDependencies ?? {}),
-        ...Object.keys(parsed.peerDependencies ?? {}),
-      ];
-
-      if (dependencyNames.includes('typescript')) {
-        reasons.push('package.json declares a TypeScript dependency');
-      }
-
-      if (
-        Array.isArray(parsed.workspaces) ||
-        (parsed.workspaces &&
-          typeof parsed.workspaces === 'object' &&
-          !Array.isArray(parsed.workspaces))
-      ) {
-        reasons.push('package.json declares package-manager workspaces');
-      }
-    } catch {
-      // Ignore invalid package.json here. The adapter load path will surface real errors later.
-    }
+  if (!existsSync(packageJsonPath) || !statSync(packageJsonPath).isFile()) {
+    return [];
   }
 
-  if (containsConventionalTypeScriptSources(rootPath)) {
-    reasons.push('conventional source folders contain .ts files');
-  }
-
-  if (reasons.length === 0) {
-    return undefined;
-  }
-
-  return {
-    packageName: '@anarchitects/governance-adapter-typescript',
-    reasons,
-  };
-}
-
-function containsConventionalTypeScriptSources(rootPath: string): boolean {
-  for (const directoryName of ['src', 'apps', 'packages', 'libs', 'services']) {
-    const directoryPath = path.join(rootPath, directoryName);
-
-    if (containsTypeScriptFile(directoryPath, 2)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-function containsTypeScriptFile(directoryPath: string, depth: number): boolean {
-  if (!existsSync(directoryPath) || !statSync(directoryPath).isDirectory()) {
-    return false;
-  }
-
-  for (const entry of readdirSync(directoryPath, { withFileTypes: true })) {
-    if (entry.isFile() && /\.(ts|tsx|mts|cts)$/.test(entry.name)) {
-      return true;
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as unknown;
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return [];
     }
 
-    if (entry.isDirectory() && depth > 0) {
-      if (
-        containsTypeScriptFile(path.join(directoryPath, entry.name), depth - 1)
-      ) {
-        return true;
-      }
-    }
-  }
+    const record = parsed as Record<string, unknown>;
+    const agovConfig =
+      typeof record.agov === 'object' &&
+      record.agov !== null &&
+      !Array.isArray(record.agov)
+        ? (record.agov as Record<string, unknown>)
+        : undefined;
+    const governanceConfig =
+      typeof record.governance === 'object' &&
+      record.governance !== null &&
+      !Array.isArray(record.governance)
+        ? (record.governance as Record<string, unknown>)
+        : undefined;
 
-  return false;
+    return [
+      ...readNonEmptyStringArray(agovConfig?.adapters),
+      ...readNonEmptyStringArray(governanceConfig?.adapters),
+    ];
+  } catch {
+    return [];
+  }
 }
 
 function renderStructuredError(
@@ -964,7 +1015,7 @@ function renderAgovCheckHelp(): string {
     '  agov check [--config <path>]',
     '',
     'Resolution order:',
-    '  explicit CLI flag -> config file -> conventions/inference -> error',
+    '  explicit CLI flag -> config file -> conventional files -> generic adapter discovery and probe -> error',
     '',
     'Options:',
     '  --help              Show check command help.',

--- a/packages/governance/cli/src/cli-boundary.spec.ts
+++ b/packages/governance/cli/src/cli-boundary.spec.ts
@@ -18,6 +18,10 @@ describe('Governance CLI boundary guardrail', () => {
       /from ['"]@anarchitects\/nx-governance['"]/,
       /anarchitecture-plugins/,
       /@anarchitects\/governance-core\//,
+      /tsconfig\.json/,
+      /tsconfig\.base\.json/,
+      /conventional source folders/,
+      /package\.json declares a TypeScript dependency/,
     ];
 
     for (const filePath of collectImplementationFiles(sourceRoot)) {

--- a/packages/governance/core/README.md
+++ b/packages/governance/core/README.md
@@ -82,7 +82,7 @@ Core contracts include:
 - signal contracts and signal breakdowns
 - snapshot and drift contracts
 - adapter input/result contracts for hosts and adapters
-- adapter contract and normalization helpers such as `GovernanceWorkspaceAdapter` and `buildGovernanceWorkspace(...)`
+- adapter contract, probe, and normalization helpers such as `GovernanceWorkspaceAdapter`, `GovernanceWorkspaceAdapterProbeResult`, and `buildGovernanceWorkspace(...)`
 - AI analysis and handoff payload contracts
 
 ### Deterministic logic

--- a/packages/governance/core/src/core/adapter.ts
+++ b/packages/governance/core/src/core/adapter.ts
@@ -13,8 +13,24 @@ export interface GovernanceWorkspaceAdapterResult {
   metadata?: Record<string, unknown>;
 }
 
+export type GovernanceWorkspaceAdapterProbeConfidence =
+  | 'none'
+  | 'low'
+  | 'medium'
+  | 'high';
+
+export interface GovernanceWorkspaceAdapterProbeResult {
+  supported: boolean;
+  confidence?: GovernanceWorkspaceAdapterProbeConfidence;
+  reasons?: string[];
+  diagnostics?: GovernanceDiagnostic[];
+  capabilities?: GovernanceCapability[];
+  metadata?: Record<string, unknown>;
+}
+
 export interface GovernanceWorkspaceAdapter<TInput = unknown> {
   id: string;
+  probe?(input: TInput): GovernanceWorkspaceAdapterProbeResult;
   loadWorkspace(input: TInput): GovernanceWorkspaceAdapterResult;
 }
 

--- a/packages/governance/core/src/core/no-nx-boundary.spec.ts
+++ b/packages/governance/core/src/core/no-nx-boundary.spec.ts
@@ -20,6 +20,8 @@ describe('Core boundary guardrail', () => {
       /from ['"]\.\.\/nx-adapter(?:\/|['"])/,
       /from ['"]\.\.\/conformance-adapter(?:\/|['"])/,
       /anarchitecture-plugins/,
+      /tsconfig\.json/,
+      /tsconfig\.base\.json/,
     ];
 
     for (const filePath of collectImplementationFiles(coreRoot)) {

--- a/tools/governance/validate-community-governance.mjs
+++ b/tools/governance/validate-community-governance.mjs
@@ -1,6 +1,11 @@
 import { spawn } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync } from 'node:fs';
-import { mkdtempSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -9,6 +14,10 @@ const workspaceRoot = resolve(
   dirname(fileURLToPath(import.meta.url)),
   '..',
   '..',
+);
+const adrPath = join(
+  workspaceRoot,
+  'docs/adr/0001-governance-package-boundaries.md',
 );
 const tempRoot = mkdtempSync(join(tmpdir(), 'governance-release-gate-'));
 const npmCacheDir = join(tempRoot, 'npm-cache');
@@ -31,6 +40,7 @@ const packages = [
     requiredReadmeTerms: [
       '@anarchitects/governance-core',
       'GovernanceWorkspaceAdapter',
+      'GovernanceWorkspaceAdapterProbeResult',
       'GovernanceWorkspaceAdapterResult',
       'buildGovernanceAssessment',
       'registerLoadedGovernanceExtensions',
@@ -51,6 +61,7 @@ const packages = [
     allowedGovernanceDeps: ['@anarchitects/governance-core'],
     requiredReadmeTerms: [
       '@anarchitects/governance-adapter-typescript',
+      'createGovernanceWorkspaceAdapter',
       'createTypeScriptWorkspaceAdapter',
       'detectTypeScriptWorkspace',
       'parsePackageManagerWorkspace',
@@ -72,8 +83,8 @@ const packages = [
       'runAgovCheck',
       'AgovCheckOptions',
       'AgovCheckResult',
-      'AgovCheckWithAdapterOptions',
-      'AgovCheckWithWorkspacePathOptions',
+      'agov',
+      '@anarchitects/governance-core',
     ],
   },
 ];
@@ -83,7 +94,9 @@ const commands = {
     validatePrerequisites();
     validateManifests();
     validateReadmes();
+    validateAdrLinks();
     validateExportMetadata();
+    validateSourceBoundaries();
     return validatePackedArtifacts();
   },
   prerequisites() {
@@ -97,6 +110,9 @@ const commands = {
   },
   exports() {
     validateExportMetadata();
+  },
+  boundaries() {
+    validateSourceBoundaries();
   },
   pack() {
     return validatePackedArtifacts();
@@ -122,6 +138,8 @@ console.log(
 );
 
 function validatePrerequisites() {
+  assertExists(adrPath);
+
   for (const pkg of packages) {
     assertExists(join(pkg.root, 'package.json'));
     assertExists(pkg.sourceIndexPath);
@@ -143,7 +161,7 @@ function validatePrerequisites() {
     join(workspaceRoot, 'packages/governance/cli/package.json'),
   );
   const cliSource = readFileSync(
-    join(workspaceRoot, 'packages/governance/cli/src/check.ts'),
+    join(workspaceRoot, 'packages/governance/cli/src/agov.ts'),
     'utf8',
   );
 
@@ -252,6 +270,31 @@ function validateReadmes() {
   );
 }
 
+function validateAdrLinks() {
+  const supportingDocs = [
+    join(workspaceRoot, 'docs/governance-package-boundaries.md'),
+    join(workspaceRoot, 'docs/governance-release-conventions.md'),
+  ];
+
+  for (const filePath of supportingDocs) {
+    const source = readFileSync(filePath, 'utf8');
+    assert(
+      source.includes('./adr/0001-governance-package-boundaries.md'),
+      `${relativePath(filePath)} must link to ADR 0001.`,
+    );
+  }
+
+  for (const pkg of packages) {
+    const readme = readFileSync(pkg.readmePath, 'utf8');
+    assert(
+      readme.includes(
+        '../../../docs/adr/0001-governance-package-boundaries.md',
+      ),
+      `${pkg.packageName} README must link to ADR 0001.`,
+    );
+  }
+}
+
 function validateExportMetadata() {
   for (const pkg of packages) {
     const manifest = readJson(join(pkg.root, 'package.json'));
@@ -266,6 +309,77 @@ function validateExportMetadata() {
       rootExport?.['@anarchitecture-community/source'] === './src/index.ts',
       `${pkg.packageName} must point source export at src/index.ts.`,
     );
+  }
+}
+
+function validateSourceBoundaries() {
+  validateCoreSourceBoundaries();
+  validateAdapterSourceBoundaries();
+  validateCliSourceBoundaries();
+}
+
+function validateCoreSourceBoundaries() {
+  const sourceRoot = join(workspaceRoot, 'packages/governance/core/src');
+  const forbiddenPatterns = [
+    /from ['"]@anarchitects\/governance-cli(?:\/|['"])/,
+    /from ['"]@anarchitects\/governance-adapter-[^'"]+(?:\/|['"])/,
+    /from ['"]@nx\//,
+    /from ['"]nx['"]/,
+    /anarchitecture-plugins/,
+    /tsconfig\.json/,
+    /tsconfig\.base\.json/,
+  ];
+
+  validateSourceFiles(sourceRoot, forbiddenPatterns, 'Governance Core');
+}
+
+function validateAdapterSourceBoundaries() {
+  const sourceRoot = join(
+    workspaceRoot,
+    'packages/governance/adapter-typescript/src',
+  );
+  const forbiddenPatterns = [
+    /from ['"]@anarchitects\/governance-cli(?:\/|['"])/,
+    /from ['"]@nx\//,
+    /from ['"]nx['"]/,
+    /anarchitecture-plugins/,
+    /@anarchitects\/governance-core\//,
+  ];
+
+  validateSourceFiles(
+    sourceRoot,
+    forbiddenPatterns,
+    'Governance TypeScript adapter',
+  );
+}
+
+function validateCliSourceBoundaries() {
+  const sourceRoot = join(workspaceRoot, 'packages/governance/cli/src');
+  const forbiddenPatterns = [
+    /from ['"]@anarchitects\/governance-adapter-[^'"]+(?:\/|['"])/,
+    /from ['"]@nx\//,
+    /from ['"]nx['"]/,
+    /anarchitecture-plugins/,
+    /@anarchitects\/governance-core\//,
+    /tsconfig\.json/,
+    /tsconfig\.base\.json/,
+    /conventional source folders/,
+    /package\.json declares a TypeScript dependency/,
+  ];
+
+  validateSourceFiles(sourceRoot, forbiddenPatterns, 'Governance CLI');
+}
+
+function validateSourceFiles(sourceRoot, forbiddenPatterns, label) {
+  for (const filePath of collectImplementationFiles(sourceRoot)) {
+    const source = readFileSync(filePath, 'utf8');
+
+    for (const pattern of forbiddenPatterns) {
+      assert(
+        !pattern.test(source),
+        `${label} contains a forbidden boundary pattern in ${relativePath(filePath)}: ${pattern}`,
+      );
+    }
   }
 }
 
@@ -308,6 +422,29 @@ async function validatePackedArtifacts() {
       packedFiles.includes('dist/index.d.ts'),
       `${pkg.packageName} tarball must include dist/index.d.ts.`,
     );
+
+    if (pkg.packageName === '@anarchitects/governance-cli') {
+      const manifest = readJson(join(pkg.root, 'package.json'));
+      const binPath = manifest.bin?.agov;
+
+      assert(
+        binPath === './dist/bin/agov.js',
+        'Governance CLI must expose agov at ./dist/bin/agov.js.',
+      );
+      assert(
+        packedFiles.includes('dist/bin/agov.js'),
+        'Governance CLI tarball must include dist/bin/agov.js.',
+      );
+
+      const builtBinPath = join(pkg.root, 'dist/bin/agov.js');
+      assertExists(builtBinPath);
+
+      const builtBin = readFileSync(builtBinPath, 'utf8');
+      assert(
+        builtBin.startsWith('#!/usr/bin/env node'),
+        'Governance CLI built agov executable must preserve the node shebang.',
+      );
+    }
 
     for (const packedFile of packedFiles) {
       assert(
@@ -395,6 +532,33 @@ function assertExists(filePath) {
     existsSync(filePath),
     `Expected file to exist: ${filePath.replace(`${workspaceRoot}/`, '')}`,
   );
+}
+
+function collectImplementationFiles(directory) {
+  return readDirectoryRecursively(directory)
+    .filter(
+      (filePath) =>
+        filePath.endsWith('.ts') &&
+        !filePath.endsWith('.spec.ts') &&
+        !filePath.endsWith('.test.ts') &&
+        !filePath.endsWith('.fixtures.ts'),
+    )
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function readDirectoryRecursively(directory) {
+  return readFileTree(directory);
+}
+
+function readFileTree(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const resolved = join(directory, entry.name);
+    return entry.isDirectory() ? readFileTree(resolved) : [resolved];
+  });
+}
+
+function relativePath(filePath) {
+  return filePath.replace(`${workspaceRoot}/`, '');
 }
 
 function assert(condition, message) {


### PR DESCRIPTION
closes #121