### PR TITLE
feat(governance-adapter-typescript): TypeScript Adapter: support configurable metadata paths

### DIFF
--- a/packages/governance/adapter-typescript/src/diagnostics.ts
+++ b/packages/governance/adapter-typescript/src/diagnostics.ts
@@ -40,24 +40,51 @@ export function unsupportedPackageMetadataFormatDiagnostic(
 
 export function invalidPackageGovernanceMetadataDiagnostic(
   filePath: string,
+  metadataPath: readonly string[] = ['governance'],
 ): TypeScriptWorkspaceDetectionDiagnostic {
+  const pathLabel = metadataPath.join('.');
+
   return {
     code: 'governance.typescript_adapter.invalid_package_governance_metadata',
-    message: `Package metadata file "${filePath}" has invalid governance metadata at "governance"; expected an object.`,
+    message: `Package metadata file "${filePath}" has invalid governance metadata at "${pathLabel}"; expected an object.`,
     source: DIAGNOSTIC_SOURCE,
-    path: '/package.json/governance',
+    path: `/package.json/${metadataPath.join('/')}`,
   };
 }
 
 export function invalidPackageGovernanceMetadataFieldDiagnostic(
   filePath: string,
   field: string,
+  metadataPath: readonly string[] = ['governance'],
 ): TypeScriptWorkspaceDetectionDiagnostic {
   return {
     code: 'governance.typescript_adapter.invalid_package_governance_metadata_field',
     message: `Package metadata file "${filePath}" has invalid governance metadata field "${field}"; expected a string value.`,
     source: DIAGNOSTIC_SOURCE,
-    path: `/package.json/governance/${field}`,
+    path: `/package.json/${metadataPath.join('/')}/${field}`,
+  };
+}
+
+export function invalidPackageGovernanceMetadataPathConfigDiagnostic(): TypeScriptWorkspaceDetectionDiagnostic {
+  return {
+    code: 'governance.typescript_adapter.invalid_package_governance_metadata_path_config',
+    message:
+      'Package governance metadata path configuration must be a non-empty array of non-empty string segments.',
+    source: DIAGNOSTIC_SOURCE,
+    path: '/packageGovernanceMetadataConfig/path',
+  };
+}
+
+export function invalidPackageGovernanceMetadataPathResolutionDiagnostic(
+  filePath: string,
+  metadataPath: readonly string[],
+  resolvedPath: readonly string[],
+): TypeScriptWorkspaceDetectionDiagnostic {
+  return {
+    code: 'governance.typescript_adapter.invalid_package_governance_metadata_path_resolution',
+    message: `Package metadata file "${filePath}" could not resolve governance metadata path "${metadataPath.join('.')}" because "${resolvedPath.join('.')}" is not an object.`,
+    source: DIAGNOSTIC_SOURCE,
+    path: `/package.json/${resolvedPath.join('/')}`,
   };
 }
 

--- a/packages/governance/adapter-typescript/src/extract-package-governance-metadata.spec.ts
+++ b/packages/governance/adapter-typescript/src/extract-package-governance-metadata.spec.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import { extractPackageGovernanceMetadata } from './extract-package-governance-metadata.js';
+import { DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG } from './workspace-adapter.js';
 
 describe('extractPackageGovernanceMetadata', () => {
   it('extracts valid default governance metadata', () => {
@@ -111,6 +112,105 @@ describe('extractPackageGovernanceMetadata', () => {
       scope: 'booking',
     });
     expect(result.diagnostics).toEqual([]);
+  });
+
+  it('supports a custom nested governance metadata path', () => {
+    const packageRoot = makeTempPackageRoot();
+    writePackageJson(
+      packageRoot,
+      JSON.stringify({
+        anarchitects: {
+          governance: {
+            domain: 'booking',
+            layer: 'domain',
+          },
+        },
+      }),
+    );
+
+    const result = extractPackageGovernanceMetadata(packageRoot, {
+      ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+      path: ['anarchitects', 'governance'],
+    });
+
+    expect(result.metadata).toEqual({
+      domain: 'booking',
+      layer: 'domain',
+    });
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it('treats a missing configured metadata path as valid absence', () => {
+    const packageRoot = makeTempPackageRoot();
+    writePackageJson(
+      packageRoot,
+      JSON.stringify({
+        governance: {
+          domain: 'booking',
+        },
+      }),
+    );
+
+    const result = extractPackageGovernanceMetadata(packageRoot, {
+      ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+      path: ['anarchitects', 'governance'],
+    });
+
+    expect(result.metadata).toBeUndefined();
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it('returns diagnostics when a configured path resolves through a non-object value', () => {
+    const packageRoot = makeTempPackageRoot();
+    writePackageJson(
+      packageRoot,
+      JSON.stringify({
+        anarchitects: 'booking',
+      }),
+    );
+
+    const result = extractPackageGovernanceMetadata(packageRoot, {
+      ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+      path: ['anarchitects', 'governance'],
+    });
+
+    expect(result.metadata).toBeUndefined();
+    expect(result.diagnostics).toEqual([
+      {
+        code: 'governance.typescript_adapter.invalid_package_governance_metadata_path_resolution',
+        message: `Package metadata file "${path.join(packageRoot, 'package.json')}" could not resolve governance metadata path "anarchitects.governance" because "anarchitects" is not an object.`,
+        source: 'governance.typescript_adapter',
+        path: '/package.json/anarchitects',
+      },
+    ]);
+  });
+
+  it('returns diagnostics for invalid metadata path configuration', () => {
+    const packageRoot = makeTempPackageRoot();
+    writePackageJson(
+      packageRoot,
+      JSON.stringify({
+        governance: {
+          domain: 'booking',
+        },
+      }),
+    );
+
+    const result = extractPackageGovernanceMetadata(packageRoot, {
+      ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+      path: [],
+    });
+
+    expect(result.metadata).toBeUndefined();
+    expect(result.diagnostics).toEqual([
+      {
+        code: 'governance.typescript_adapter.invalid_package_governance_metadata_path_config',
+        message:
+          'Package governance metadata path configuration must be a non-empty array of non-empty string segments.',
+        source: 'governance.typescript_adapter',
+        path: '/packageGovernanceMetadataConfig/path',
+      },
+    ]);
   });
 });
 

--- a/packages/governance/adapter-typescript/src/extract-package-governance-metadata.ts
+++ b/packages/governance/adapter-typescript/src/extract-package-governance-metadata.ts
@@ -1,10 +1,13 @@
 import {
   invalidPackageGovernanceMetadataDiagnostic,
   invalidPackageGovernanceMetadataFieldDiagnostic,
+  invalidPackageGovernanceMetadataPathConfigDiagnostic,
+  invalidPackageGovernanceMetadataPathResolutionDiagnostic,
 } from './diagnostics.js';
 import { loadPackageMetadata } from './load-package-metadata.js';
 import { DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG } from './workspace-adapter.js';
 import type {
+  TypeScriptPackageGovernanceMetadataConfig,
   TypeScriptPackageGovernanceMetadata,
   TypeScriptWorkspaceDetectionDiagnostic,
 } from './types.js';
@@ -17,8 +20,20 @@ export interface ExtractPackageGovernanceMetadataResult {
 
 export function extractPackageGovernanceMetadata(
   packageRoot: string,
+  config: TypeScriptPackageGovernanceMetadataConfig = DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
 ): ExtractPackageGovernanceMetadataResult {
   const loaded = loadPackageMetadata(packageRoot);
+  const metadataPath = normalizeMetadataPath(config.path);
+
+  if (!metadataPath) {
+    return {
+      packageJsonPath: loaded.packageJsonPath,
+      diagnostics: [
+        ...loaded.diagnostics,
+        invalidPackageGovernanceMetadataPathConfigDiagnostic(),
+      ],
+    };
+  }
 
   if (!loaded.packageJson) {
     return {
@@ -32,7 +47,9 @@ export function extractPackageGovernanceMetadata(
   ];
   const governanceValue = resolvePath(
     loaded.packageJson,
-    DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG.path,
+    metadataPath,
+    loaded.packageJsonPath,
+    diagnostics,
   );
 
   if (governanceValue === undefined) {
@@ -46,7 +63,10 @@ export function extractPackageGovernanceMetadata(
 
   if (!governanceRecord) {
     diagnostics.push(
-      invalidPackageGovernanceMetadataDiagnostic(loaded.packageJsonPath),
+      invalidPackageGovernanceMetadataDiagnostic(
+        loaded.packageJsonPath,
+        metadataPath,
+      ),
     );
 
     return {
@@ -71,6 +91,7 @@ export function extractPackageGovernanceMetadata(
         invalidPackageGovernanceMetadataFieldDiagnostic(
           loaded.packageJsonPath,
           sourceField,
+          metadataPath,
         ),
       );
       continue;
@@ -93,20 +114,46 @@ const GOVERNANCE_METADATA_FIELDS = [
   'owner',
 ] as const;
 
-function resolvePath(value: unknown, pathSegments: readonly string[]): unknown {
+function resolvePath(
+  value: unknown,
+  pathSegments: readonly string[],
+  filePath: string,
+  diagnostics: TypeScriptWorkspaceDetectionDiagnostic[],
+): unknown {
   let current: unknown = value;
+  const resolvedPath: string[] = [];
 
   for (const segment of pathSegments) {
     const currentRecord = asRecord(current);
 
     if (!currentRecord) {
+      diagnostics.push(
+        invalidPackageGovernanceMetadataPathResolutionDiagnostic(
+          filePath,
+          pathSegments,
+          resolvedPath,
+        ),
+      );
+      return undefined;
+    }
+
+    if (!(segment in currentRecord)) {
       return undefined;
     }
 
     current = currentRecord[segment];
+    resolvedPath.push(segment);
   }
 
   return current;
+}
+
+function normalizeMetadataPath(
+  pathSegments: readonly string[],
+): string[] | undefined {
+  return pathSegments.length > 0 && pathSegments.every(isNonEmptyString)
+    ? [...pathSegments]
+    : undefined;
 }
 
 function hasMetadataFields(
@@ -121,4 +168,8 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : undefined;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
 }


### PR DESCRIPTION
closes #178