### PR TITLE
feat(governance-adapter-typescript): TypeScript Adapter: support configurable governance field mapping

### DIFF
--- a/packages/governance/adapter-typescript/src/diagnostics.ts
+++ b/packages/governance/adapter-typescript/src/diagnostics.ts
@@ -88,6 +88,17 @@ export function invalidPackageGovernanceMetadataPathResolutionDiagnostic(
   };
 }
 
+export function invalidPackageGovernanceMetadataFieldMappingConfigDiagnostic(
+  field: string,
+): TypeScriptWorkspaceDetectionDiagnostic {
+  return {
+    code: 'governance.typescript_adapter.invalid_package_governance_metadata_field_mapping_config',
+    message: `Package governance metadata field mapping for "${field}" must be a non-empty string.`,
+    source: DIAGNOSTIC_SOURCE,
+    path: `/packageGovernanceMetadataConfig/fields/${field}`,
+  };
+}
+
 export function partialWorkspaceDetectionDiagnostic(
   indicators: TypeScriptWorkspaceIndicators,
 ): TypeScriptWorkspaceDetectionDiagnostic {

--- a/packages/governance/adapter-typescript/src/extract-package-governance-metadata.spec.ts
+++ b/packages/governance/adapter-typescript/src/extract-package-governance-metadata.spec.ts
@@ -114,6 +114,160 @@ describe('extractPackageGovernanceMetadata', () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  it('supports a custom governance field mapping', () => {
+    const packageRoot = makeTempPackageRoot();
+    writePackageJson(
+      packageRoot,
+      JSON.stringify({
+        governance: {
+          boundedContext: 'booking',
+          architecturalLayer: 'domain',
+          moduleScope: 'booking',
+          owningTeam: 'booking-team',
+        },
+      }),
+    );
+
+    const result = extractPackageGovernanceMetadata(packageRoot, {
+      ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+      fields: {
+        domain: 'boundedContext',
+        layer: 'architecturalLayer',
+        scope: 'moduleScope',
+        owner: 'owningTeam',
+      },
+    });
+
+    expect(result.metadata).toEqual({
+      domain: 'booking',
+      layer: 'domain',
+      scope: 'booking',
+      owner: 'booking-team',
+    });
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it('extracts partial governance metadata with a custom field mapping', () => {
+    const packageRoot = makeTempPackageRoot();
+    writePackageJson(
+      packageRoot,
+      JSON.stringify({
+        governance: {
+          boundedContext: 'booking',
+          moduleScope: 'booking',
+        },
+      }),
+    );
+
+    const result = extractPackageGovernanceMetadata(packageRoot, {
+      ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+      fields: {
+        domain: 'boundedContext',
+        layer: 'architecturalLayer',
+        scope: 'moduleScope',
+        owner: 'owningTeam',
+      },
+    });
+
+    expect(result.metadata).toEqual({
+      domain: 'booking',
+      scope: 'booking',
+    });
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it('handles missing mapped fields gracefully', () => {
+    const packageRoot = makeTempPackageRoot();
+    writePackageJson(
+      packageRoot,
+      JSON.stringify({
+        governance: {
+          boundedContext: 'booking',
+        },
+      }),
+    );
+
+    const result = extractPackageGovernanceMetadata(packageRoot, {
+      ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+      fields: {
+        domain: 'boundedContext',
+        layer: 'architecturalLayer',
+        scope: 'moduleScope',
+        owner: 'owningTeam',
+      },
+    });
+
+    expect(result.metadata).toEqual({
+      domain: 'booking',
+    });
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  it('returns diagnostics for invalid field mapping configuration and falls back to defaults', () => {
+    const packageRoot = makeTempPackageRoot();
+    writePackageJson(
+      packageRoot,
+      JSON.stringify({
+        governance: {
+          domain: 'booking',
+          owner: 'booking-team',
+        },
+      }),
+    );
+
+    const result = extractPackageGovernanceMetadata(packageRoot, {
+      ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+      fields: {
+        ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG.fields,
+        owner: '',
+      },
+    });
+
+    expect(result.metadata).toEqual({
+      domain: 'booking',
+      owner: 'booking-team',
+    });
+    expect(result.diagnostics).toEqual([
+      {
+        code: 'governance.typescript_adapter.invalid_package_governance_metadata_field_mapping_config',
+        message:
+          'Package governance metadata field mapping for "owner" must be a non-empty string.',
+        source: 'governance.typescript_adapter',
+        path: '/packageGovernanceMetadataConfig/fields/owner',
+      },
+    ]);
+  });
+
+  it('falls back to default field mappings when some mappings are omitted', () => {
+    const packageRoot = makeTempPackageRoot();
+    writePackageJson(
+      packageRoot,
+      JSON.stringify({
+        governance: {
+          boundedContext: 'booking',
+          layer: 'domain',
+          scope: 'booking',
+          owner: 'booking-team',
+        },
+      }),
+    );
+
+    const result = extractPackageGovernanceMetadata(packageRoot, {
+      ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+      fields: {
+        domain: 'boundedContext',
+      },
+    });
+
+    expect(result.metadata).toEqual({
+      domain: 'booking',
+      layer: 'domain',
+      scope: 'booking',
+      owner: 'booking-team',
+    });
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it('supports a custom nested governance metadata path', () => {
     const packageRoot = makeTempPackageRoot();
     writePackageJson(

--- a/packages/governance/adapter-typescript/src/extract-package-governance-metadata.ts
+++ b/packages/governance/adapter-typescript/src/extract-package-governance-metadata.ts
@@ -1,6 +1,7 @@
 import {
   invalidPackageGovernanceMetadataDiagnostic,
   invalidPackageGovernanceMetadataFieldDiagnostic,
+  invalidPackageGovernanceMetadataFieldMappingConfigDiagnostic,
   invalidPackageGovernanceMetadataPathConfigDiagnostic,
   invalidPackageGovernanceMetadataPathResolutionDiagnostic,
 } from './diagnostics.js';
@@ -24,6 +25,7 @@ export function extractPackageGovernanceMetadata(
 ): ExtractPackageGovernanceMetadataResult {
   const loaded = loadPackageMetadata(packageRoot);
   const metadataPath = normalizeMetadataPath(config.path);
+  const fieldMapping = normalizeFieldMapping(config.fields);
 
   if (!metadataPath) {
     return {
@@ -31,6 +33,7 @@ export function extractPackageGovernanceMetadata(
       diagnostics: [
         ...loaded.diagnostics,
         invalidPackageGovernanceMetadataPathConfigDiagnostic(),
+        ...fieldMapping.diagnostics,
       ],
     };
   }
@@ -38,12 +41,13 @@ export function extractPackageGovernanceMetadata(
   if (!loaded.packageJson) {
     return {
       packageJsonPath: loaded.packageJsonPath,
-      diagnostics: [...loaded.diagnostics],
+      diagnostics: [...loaded.diagnostics, ...fieldMapping.diagnostics],
     };
   }
 
   const diagnostics: TypeScriptWorkspaceDetectionDiagnostic[] = [
     ...loaded.diagnostics,
+    ...fieldMapping.diagnostics,
   ];
   const governanceValue = resolvePath(
     loaded.packageJson,
@@ -78,8 +82,7 @@ export function extractPackageGovernanceMetadata(
   const metadata: TypeScriptPackageGovernanceMetadata = {};
 
   for (const targetField of GOVERNANCE_METADATA_FIELDS) {
-    const sourceField =
-      DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG.fields[targetField];
+    const sourceField = fieldMapping.fields[targetField];
     const fieldValue = governanceRecord[sourceField];
 
     if (fieldValue === undefined) {
@@ -154,6 +157,40 @@ function normalizeMetadataPath(
   return pathSegments.length > 0 && pathSegments.every(isNonEmptyString)
     ? [...pathSegments]
     : undefined;
+}
+
+function normalizeFieldMapping(
+  fields: TypeScriptPackageGovernanceMetadataConfig['fields'],
+): {
+  fields: Record<(typeof GOVERNANCE_METADATA_FIELDS)[number], string>;
+  diagnostics: TypeScriptWorkspaceDetectionDiagnostic[];
+} {
+  const diagnostics: TypeScriptWorkspaceDetectionDiagnostic[] = [];
+  const normalized = {
+    ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG.fields,
+  } as Record<(typeof GOVERNANCE_METADATA_FIELDS)[number], string>;
+
+  for (const field of GOVERNANCE_METADATA_FIELDS) {
+    const configuredField = fields[field];
+
+    if (configuredField === undefined) {
+      continue;
+    }
+
+    if (!isNonEmptyString(configuredField)) {
+      diagnostics.push(
+        invalidPackageGovernanceMetadataFieldMappingConfigDiagnostic(field),
+      );
+      continue;
+    }
+
+    normalized[field] = configuredField;
+  }
+
+  return {
+    fields: normalized,
+    diagnostics,
+  };
 }
 
 function hasMetadataFields(

--- a/packages/governance/adapter-typescript/src/types.ts
+++ b/packages/governance/adapter-typescript/src/types.ts
@@ -59,10 +59,10 @@ export interface TypeScriptProjectDiscoveryConfig {
 }
 
 export interface TypeScriptPackageGovernanceMetadataFieldMapping {
-  domain: string;
-  layer: string;
-  scope: string;
-  owner: string;
+  domain?: string;
+  layer?: string;
+  scope?: string;
+  owner?: string;
 }
 
 export interface TypeScriptPackageGovernanceMetadataConfig {


### PR DESCRIPTION
closes #179