### PR TITLE
feat(governance-adapter-typescript): TypeScript Adapter: generate governance tags from package metadata

### DIFF
--- a/packages/governance/adapter-typescript/src/project-discovery.spec.ts
+++ b/packages/governance/adapter-typescript/src/project-discovery.spec.ts
@@ -342,7 +342,7 @@ describe('TypeScript project discovery', () => {
         name: 'order',
         root: 'packages/order',
         type: 'unknown',
-        tags: [],
+        tags: ['domain:booking', 'layer:domain', 'scope:booking'],
         domain: 'booking',
         layer: 'domain',
         scope: 'booking',
@@ -455,7 +455,7 @@ describe('TypeScript project discovery', () => {
         name: 'order',
         root: 'packages/order',
         type: 'unknown',
-        tags: ['layer:application'],
+        tags: ['layer:application', 'domain:booking'],
         domain: 'booking',
         layer: 'application',
         metadata: {
@@ -497,7 +497,12 @@ describe('TypeScript project discovery', () => {
         name: 'customer-application',
         root: 'libs/customer/application',
         type: 'unknown',
-        tags: ['scope:customer', 'layer:application'],
+        tags: [
+          'scope:customer',
+          'layer:application',
+          'domain:booking',
+          'layer:domain',
+        ],
         domain: 'booking',
         layer: 'domain',
         scope: 'customer',
@@ -505,6 +510,123 @@ describe('TypeScript project discovery', () => {
       },
     ]);
     expect(result.diagnostics).toEqual([]);
+  });
+
+  it('merges metadata-derived tags with existing discovery-rule tags deterministically', () => {
+    const packageRoot = makeTempPackageRoot({
+      governance: {
+        domain: 'booking',
+        scope: 'ordering',
+      },
+    });
+
+    const result = discoverTypeScriptProjects(
+      workspace({
+        workspaceRoot: packageRoot.workspaceRoot,
+        packageRoots: ['packages/order'],
+      }),
+      {
+        projects: [
+          {
+            pattern: 'packages/*',
+            name: '{segment:1}',
+            tags: ['type:lib', 'layer:application'],
+          },
+        ],
+      },
+      DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+    );
+
+    expect(result.projects[0]?.tags).toEqual([
+      'type:lib',
+      'layer:application',
+      'domain:booking',
+      'scope:ordering',
+    ]);
+  });
+
+  it('removes duplicate metadata-derived tags', () => {
+    const packageRoot = makeTempPackageRoot({
+      governance: {
+        layer: 'application',
+      },
+    });
+
+    const result = discoverTypeScriptProjects(
+      workspace({
+        workspaceRoot: packageRoot.workspaceRoot,
+        packageRoots: ['packages/order'],
+      }),
+      {
+        projects: [
+          {
+            pattern: 'packages/*',
+            name: '{segment:1}',
+            tags: ['layer:application', 'layer:application'],
+          },
+        ],
+      },
+      DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+    );
+
+    expect(result.projects[0]?.tags).toEqual(['layer:application']);
+  });
+
+  it('preserves existing tags when metadata is absent', () => {
+    const packageRoot = makeTempPackageRoot();
+
+    const result = discoverTypeScriptProjects(
+      workspace({
+        workspaceRoot: packageRoot.workspaceRoot,
+        packageRoots: ['packages/order'],
+      }),
+      {
+        projects: [
+          {
+            pattern: 'packages/*',
+            name: '{segment:1}',
+            tags: ['type:lib'],
+          },
+        ],
+      },
+      DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+    );
+
+    expect(result.projects[0]?.tags).toEqual(['type:lib']);
+  });
+
+  it('keeps metadata-generated tag ordering deterministic', () => {
+    const packageRoot = makeTempPackageRoot({
+      governance: {
+        scope: 'ordering',
+        domain: 'booking',
+        layer: 'application',
+      },
+    });
+
+    const result = discoverTypeScriptProjects(
+      workspace({
+        workspaceRoot: packageRoot.workspaceRoot,
+        packageRoots: ['packages/order'],
+      }),
+      {
+        projects: [
+          {
+            pattern: 'packages/*',
+            name: '{segment:1}',
+            tags: ['type:lib'],
+          },
+        ],
+      },
+      DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+    );
+
+    expect(result.projects[0]?.tags).toEqual([
+      'type:lib',
+      'domain:booking',
+      'layer:application',
+      'scope:ordering',
+    ]);
   });
 
   it('does not import Nx APIs', () => {

--- a/packages/governance/adapter-typescript/src/project-discovery.ts
+++ b/packages/governance/adapter-typescript/src/project-discovery.ts
@@ -190,17 +190,55 @@ function createGovernanceProject({
   metadataLayer?: string;
   metadataScope?: string;
 }): GovernanceProjectInput {
+  const resolvedDomain = metadataDomain ?? domain;
+  const resolvedLayer = metadataLayer ?? layer;
+  const resolvedScope = metadataScope ?? scope;
+
   return {
     id: name,
     name,
     root,
     type: 'unknown',
-    tags,
-    ...((metadataDomain ?? domain) ? { domain: metadataDomain ?? domain } : {}),
-    ...((metadataLayer ?? layer) ? { layer: metadataLayer ?? layer } : {}),
-    ...((metadataScope ?? scope) ? { scope: metadataScope ?? scope } : {}),
+    tags: mergeProjectTags(tags, resolvedDomain, resolvedLayer, resolvedScope),
+    ...(resolvedDomain ? { domain: resolvedDomain } : {}),
+    ...(resolvedLayer ? { layer: resolvedLayer } : {}),
+    ...(resolvedScope ? { scope: resolvedScope } : {}),
     metadata: owner ? { owner } : {},
   };
+}
+
+function mergeProjectTags(
+  existingTags: readonly string[],
+  domain?: string,
+  layer?: string,
+  scope?: string,
+): string[] {
+  const merged: string[] = [];
+  const seenTags = new Set<string>();
+
+  for (const tag of existingTags) {
+    if (seenTags.has(tag)) {
+      continue;
+    }
+
+    seenTags.add(tag);
+    merged.push(tag);
+  }
+
+  for (const tag of [
+    ...(domain ? [`domain:${domain}`] : []),
+    ...(layer ? [`layer:${layer}`] : []),
+    ...(scope ? [`scope:${scope}`] : []),
+  ]) {
+    if (seenTags.has(tag)) {
+      continue;
+    }
+
+    seenTags.add(tag);
+    merged.push(tag);
+  }
+
+  return merged;
 }
 
 function normalizeDiscoveryPattern(pattern: unknown): string | undefined {


### PR DESCRIPTION
closes #181