### PR TITLE
feat(governance-adapter-typescript): TypeScript Adapter: add governance metadata diagnostics

### DIFF
--- a/packages/governance/adapter-typescript/src/diagnostics.ts
+++ b/packages/governance/adapter-typescript/src/diagnostics.ts
@@ -99,6 +99,16 @@ export function invalidPackageGovernanceMetadataFieldMappingConfigDiagnostic(
   };
 }
 
+export function invalidPackageGovernanceMetadataFieldMappingFormatDiagnostic(): TypeScriptWorkspaceDetectionDiagnostic {
+  return {
+    code: 'governance.typescript_adapter.invalid_package_governance_metadata_field_mapping_format',
+    message:
+      'Package governance metadata field mapping configuration must be an object when provided.',
+    source: DIAGNOSTIC_SOURCE,
+    path: '/packageGovernanceMetadataConfig/fields',
+  };
+}
+
 export function partialWorkspaceDetectionDiagnostic(
   indicators: TypeScriptWorkspaceIndicators,
 ): TypeScriptWorkspaceDetectionDiagnostic {

--- a/packages/governance/adapter-typescript/src/extract-package-governance-metadata.spec.ts
+++ b/packages/governance/adapter-typescript/src/extract-package-governance-metadata.spec.ts
@@ -93,6 +93,33 @@ describe('extractPackageGovernanceMetadata', () => {
     ]);
   });
 
+  it('returns diagnostics for empty-string governance field values', () => {
+    const packageRoot = makeTempPackageRoot();
+    writePackageJson(
+      packageRoot,
+      JSON.stringify({
+        governance: {
+          domain: '',
+          scope: 'booking',
+        },
+      }),
+    );
+
+    const result = extractPackageGovernanceMetadata(packageRoot);
+
+    expect(result.metadata).toEqual({
+      scope: 'booking',
+    });
+    expect(result.diagnostics).toEqual([
+      {
+        code: 'governance.typescript_adapter.invalid_package_governance_metadata_field',
+        message: `Package metadata file "${path.join(packageRoot, 'package.json')}" has invalid governance metadata field "domain"; expected a string value.`,
+        source: 'governance.typescript_adapter',
+        path: '/package.json/governance/domain',
+      },
+    ]);
+  });
+
   it('extracts partial governance metadata when present', () => {
     const packageRoot = makeTempPackageRoot();
     writePackageJson(
@@ -363,6 +390,111 @@ describe('extractPackageGovernanceMetadata', () => {
           'Package governance metadata path configuration must be a non-empty array of non-empty string segments.',
         source: 'governance.typescript_adapter',
         path: '/packageGovernanceMetadataConfig/path',
+      },
+    ]);
+  });
+
+  it('returns diagnostics for non-array metadata path configuration', () => {
+    const packageRoot = makeTempPackageRoot();
+    writePackageJson(packageRoot, JSON.stringify({ governance: {} }));
+
+    const result = extractPackageGovernanceMetadata(packageRoot, {
+      ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+      path: 'governance' as unknown as string[],
+    });
+
+    expect(result.metadata).toBeUndefined();
+    expect(result.diagnostics).toEqual([
+      {
+        code: 'governance.typescript_adapter.invalid_package_governance_metadata_path_config',
+        message:
+          'Package governance metadata path configuration must be a non-empty array of non-empty string segments.',
+        source: 'governance.typescript_adapter',
+        path: '/packageGovernanceMetadataConfig/path',
+      },
+    ]);
+  });
+
+  it('returns diagnostics for metadata path segments that are not non-empty strings', () => {
+    const packageRoot = makeTempPackageRoot();
+    writePackageJson(packageRoot, JSON.stringify({ governance: {} }));
+
+    const result = extractPackageGovernanceMetadata(packageRoot, {
+      ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+      path: ['governance', ''] as unknown as string[],
+    });
+
+    expect(result.metadata).toBeUndefined();
+    expect(result.diagnostics).toEqual([
+      {
+        code: 'governance.typescript_adapter.invalid_package_governance_metadata_path_config',
+        message:
+          'Package governance metadata path configuration must be a non-empty array of non-empty string segments.',
+        source: 'governance.typescript_adapter',
+        path: '/packageGovernanceMetadataConfig/path',
+      },
+    ]);
+  });
+
+  it('returns diagnostics for malformed field mapping configuration', () => {
+    const packageRoot = makeTempPackageRoot();
+    writePackageJson(
+      packageRoot,
+      JSON.stringify({
+        governance: {
+          domain: 'booking',
+        },
+      }),
+    );
+
+    const result = extractPackageGovernanceMetadata(packageRoot, {
+      ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+      fields: 'invalid' as unknown as Record<string, string>,
+    });
+
+    expect(result.metadata).toEqual({
+      domain: 'booking',
+    });
+    expect(result.diagnostics).toEqual([
+      {
+        code: 'governance.typescript_adapter.invalid_package_governance_metadata_field_mapping_format',
+        message:
+          'Package governance metadata field mapping configuration must be an object when provided.',
+        source: 'governance.typescript_adapter',
+        path: '/packageGovernanceMetadataConfig/fields',
+      },
+    ]);
+  });
+
+  it('returns diagnostics for non-string field mapping values', () => {
+    const packageRoot = makeTempPackageRoot();
+    writePackageJson(
+      packageRoot,
+      JSON.stringify({
+        governance: {
+          domain: 'booking',
+        },
+      }),
+    );
+
+    const result = extractPackageGovernanceMetadata(packageRoot, {
+      ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+      fields: {
+        ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG.fields,
+        domain: 42 as unknown as string,
+      },
+    });
+
+    expect(result.metadata).toEqual({
+      domain: 'booking',
+    });
+    expect(result.diagnostics).toEqual([
+      {
+        code: 'governance.typescript_adapter.invalid_package_governance_metadata_field_mapping_config',
+        message:
+          'Package governance metadata field mapping for "domain" must be a non-empty string.',
+        source: 'governance.typescript_adapter',
+        path: '/packageGovernanceMetadataConfig/fields/domain',
       },
     ]);
   });

--- a/packages/governance/adapter-typescript/src/extract-package-governance-metadata.ts
+++ b/packages/governance/adapter-typescript/src/extract-package-governance-metadata.ts
@@ -2,6 +2,7 @@ import {
   invalidPackageGovernanceMetadataDiagnostic,
   invalidPackageGovernanceMetadataFieldDiagnostic,
   invalidPackageGovernanceMetadataFieldMappingConfigDiagnostic,
+  invalidPackageGovernanceMetadataFieldMappingFormatDiagnostic,
   invalidPackageGovernanceMetadataPathConfigDiagnostic,
   invalidPackageGovernanceMetadataPathResolutionDiagnostic,
 } from './diagnostics.js';
@@ -24,8 +25,12 @@ export function extractPackageGovernanceMetadata(
   config: TypeScriptPackageGovernanceMetadataConfig = DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
 ): ExtractPackageGovernanceMetadataResult {
   const loaded = loadPackageMetadata(packageRoot);
-  const metadataPath = normalizeMetadataPath(config.path);
-  const fieldMapping = normalizeFieldMapping(config.fields);
+  const metadataPath = normalizeMetadataPath(
+    (config as unknown as { path?: unknown }).path,
+  );
+  const fieldMapping = normalizeFieldMapping(
+    (config as unknown as { fields?: unknown }).fields,
+  );
 
   if (!metadataPath) {
     return {
@@ -89,7 +94,7 @@ export function extractPackageGovernanceMetadata(
       continue;
     }
 
-    if (typeof fieldValue !== 'string') {
+    if (!isNonEmptyString(fieldValue)) {
       diagnostics.push(
         invalidPackageGovernanceMetadataFieldDiagnostic(
           loaded.packageJsonPath,
@@ -151,17 +156,17 @@ function resolvePath(
   return current;
 }
 
-function normalizeMetadataPath(
-  pathSegments: readonly string[],
-): string[] | undefined {
+function normalizeMetadataPath(pathSegments: unknown): string[] | undefined {
+  if (!Array.isArray(pathSegments)) {
+    return undefined;
+  }
+
   return pathSegments.length > 0 && pathSegments.every(isNonEmptyString)
     ? [...pathSegments]
     : undefined;
 }
 
-function normalizeFieldMapping(
-  fields: TypeScriptPackageGovernanceMetadataConfig['fields'],
-): {
+function normalizeFieldMapping(fields: unknown): {
   fields: Record<(typeof GOVERNANCE_METADATA_FIELDS)[number], string>;
   diagnostics: TypeScriptWorkspaceDetectionDiagnostic[];
 } {
@@ -170,8 +175,27 @@ function normalizeFieldMapping(
     ...DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG.fields,
   } as Record<(typeof GOVERNANCE_METADATA_FIELDS)[number], string>;
 
+  if (fields === undefined) {
+    return {
+      fields: normalized,
+      diagnostics,
+    };
+  }
+
+  const fieldsRecord = asRecord(fields);
+
+  if (!fieldsRecord) {
+    diagnostics.push(
+      invalidPackageGovernanceMetadataFieldMappingFormatDiagnostic(),
+    );
+    return {
+      fields: normalized,
+      diagnostics,
+    };
+  }
+
   for (const field of GOVERNANCE_METADATA_FIELDS) {
-    const configuredField = fields[field];
+    const configuredField = fieldsRecord[field];
 
     if (configuredField === undefined) {
       continue;

--- a/packages/governance/adapter-typescript/src/project-discovery.spec.ts
+++ b/packages/governance/adapter-typescript/src/project-discovery.spec.ts
@@ -806,6 +806,49 @@ describe('TypeScript project discovery', () => {
     ]);
   });
 
+  it('includes metadata diagnostics and continues discovery when package metadata is invalid', () => {
+    const packageRoot = makeTempPackageRoot({
+      governance: {
+        domain: 42,
+      },
+    });
+
+    const result = discoverTypeScriptProjects(
+      workspace({
+        workspaceRoot: packageRoot.workspaceRoot,
+        packageRoots: ['packages/order'],
+      }),
+      {
+        projects: [
+          {
+            pattern: 'packages/*',
+            name: '{segment:1}',
+          },
+        ],
+      },
+      DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+    );
+
+    expect(result.projects).toEqual([
+      {
+        id: 'order',
+        name: 'order',
+        root: 'packages/order',
+        type: 'unknown',
+        tags: [],
+        metadata: {},
+      },
+    ]);
+    expect(result.diagnostics).toEqual([
+      {
+        code: 'governance.typescript_adapter.invalid_package_governance_metadata_field',
+        message: `Package metadata file "${path.join(packageRoot.workspaceRoot, 'packages/order/package.json')}" has invalid governance metadata field "domain"; expected a string value.`,
+        source: 'governance.typescript_adapter',
+        path: '/package.json/governance/domain',
+      },
+    ]);
+  });
+
   it('does not import Nx APIs', () => {
     const discoverySource = readFileSync(
       path.join(specDir, 'project-discovery.ts'),


### PR DESCRIPTION
closes #183