### PR TITLE
docs(governance-adapter-typescript): TypeScript Adapter: document package governance metadata

### DIFF
--- a/packages/governance/adapter-typescript/README.md
+++ b/packages/governance/adapter-typescript/README.md
@@ -6,7 +6,7 @@ Platform-independent TypeScript workspace discovery and normalization for Govern
 
 `@anarchitects/governance-adapter-typescript` reads a TypeScript-oriented workspace as plain files and maps the result into contracts owned by `@anarchitects/governance-core`.
 
-The package focuses on discovery and normalization, not on owning the canonical Governance model. It is intended for hosts that need to inspect a TypeScript workspace outside Nx and then feed the normalized result into Governance Core.
+The package focuses on discovery and normalization, not on owning the canonical Governance model. It is intended for hosts that need to inspect a TypeScript workspace from repository files and then feed the normalized result into Governance Core.
 
 ## Responsibilities
 
@@ -24,10 +24,10 @@ This package is not responsible for:
 
 - CLI command behavior
 - canonical Governance contracts
-- Nx graph loading
-- Nx metadata extraction
-- Nx plugin runtime behavior
-- Nx executors or generators
+- external project-graph APIs
+- framework-specific metadata extraction
+- plugin runtime behavior
+- executor or generator ownership
 
 ## Supported Assumptions
 
@@ -36,7 +36,7 @@ The current implementation assumes:
 - workspace detection based on plain package-manager files such as `pnpm-workspace.yaml` and `package.json#workspaces`
 - `tsconfig` parsing through root `tsconfig.json`, `tsconfig.base.json`, and deterministic `extends` chains
 - static analysis of relative imports, package-name imports, `compilerOptions.paths`, `baseUrl`, re-exports, and string-literal dynamic imports
-- project discovery from package-manager workspace roots rather than from Nx graph APIs
+- project discovery from package-manager workspace roots
 
 ## Public API
 
@@ -152,6 +152,143 @@ const dependencyMapping = mapTypeScriptImportsToGovernanceDependencies({
 });
 ```
 
+## Package Governance Metadata
+
+The adapter can read governance metadata from each discovered package
+`package.json` and merge it into the discovered `GovernanceProjectInput`.
+
+### Default `package.json` Shape
+
+By default, metadata is read from `package.json#governance`.
+
+```json
+{
+  "governance": {
+    "domain": "booking",
+    "layer": "domain",
+    "scope": "booking",
+    "owner": "booking-team"
+  }
+}
+```
+
+### Configurable Metadata Path
+
+The default metadata path is:
+
+- `governance`
+
+You can configure a nested path, for example:
+
+- `anarchitects.governance`
+
+### Configurable Field Mapping
+
+Default field mapping:
+
+- `domain -> domain`
+- `layer -> layer`
+- `scope -> scope`
+- `owner -> owner`
+
+Custom field mapping example:
+
+- `domain -> boundedContext`
+- `layer -> architecturalLayer`
+- `scope -> moduleScope`
+- `owner -> owningTeam`
+
+### Mapping Into `GovernanceProjectInput`
+
+Extracted metadata is mapped as follows:
+
+- metadata `domain` -> `project.domain`
+- metadata `layer` -> `project.layer`
+- metadata `scope` -> `project.scope`
+- metadata `owner` -> `project.metadata.owner`
+
+### Generated Tags
+
+After governance values are resolved, tags are generated from:
+
+- `domain:<value>`
+- `layer:<value>`
+- `scope:<value>`
+
+`owner` is stored in `project.metadata.owner` and is not converted into a tag.
+
+### Precedence Rules
+
+Resolution is deterministic:
+
+- package metadata overrides discovery-derived `domain`, `layer`, and `scope`
+  when metadata values are present
+- discovery-derived values remain fallback when package metadata is absent
+- partial package metadata overrides only the fields that are present
+- generated governance tags reflect the final resolved
+  `domain`/`layer`/`scope` values
+
+### Diagnostics Behavior
+
+The adapter reports deterministic diagnostics for metadata problems while still
+returning discovery results where possible.
+
+- invalid metadata structures produce diagnostics
+- invalid metadata paths produce diagnostics
+- invalid field mappings produce diagnostics
+- discovery continues where possible, including when a package has metadata
+  diagnostics
+- packages without governance metadata are valid and do not emit metadata
+  diagnostics
+
+### Configuration Examples
+
+Default configuration:
+
+```ts
+import { createGovernanceWorkspaceAdapter } from '@anarchitects/governance-adapter-typescript';
+
+const adapter = createGovernanceWorkspaceAdapter();
+```
+
+Custom metadata path:
+
+```ts
+import { createGovernanceWorkspaceAdapter } from '@anarchitects/governance-adapter-typescript';
+
+const adapter = createGovernanceWorkspaceAdapter({
+  packageGovernanceMetadataConfig: {
+    sourceFile: 'package.json',
+    path: ['anarchitects', 'governance'],
+    fields: {
+      domain: 'domain',
+      layer: 'layer',
+      scope: 'scope',
+      owner: 'owner',
+    },
+  },
+});
+```
+
+Custom field mapping:
+
+```ts
+import { createGovernanceWorkspaceAdapter } from '@anarchitects/governance-adapter-typescript';
+
+const adapter = createGovernanceWorkspaceAdapter({
+  packageGovernanceMetadataConfig: {
+    sourceFile: 'package.json',
+    path: ['governance'],
+    fields: {
+      domain: 'boundedContext',
+      layer: 'architecturalLayer',
+      scope: 'moduleScope',
+      owner: 'owningTeam',
+    },
+  },
+});
+```
+
 ## Normalization into Governance Core
 
 This adapter normalizes into `@anarchitects/governance-core` contracts rather than defining a parallel model.
@@ -166,17 +303,17 @@ Hosts can combine these results with Core-owned assessment, rule, signal, and ex
 
 ## Package Boundaries
 
-`@anarchitects/governance-adapter-typescript` is explicitly non-Nx.
+`@anarchitects/governance-adapter-typescript` is framework-independent.
 
 That means:
 
-- no `@nx/devkit`
-- no `nx`
-- no Nx graph loading
-- no Nx plugin runtime assumptions
+- no framework-specific devkit dependency
+- no framework-specific CLI dependency
+- no external project-graph loading dependency
+- no framework plugin runtime assumptions
 - no executor or generator ownership
 
-The package reads repository files directly and stays usable in plain TypeScript or mixed monorepo environments without requiring Nx.
+The package reads repository files directly and stays usable in plain TypeScript or mixed monorepo environments.
 
 For detailed package-boundary rules and the adapter ownership model, see
 [ADR 0001: Governance Package Boundaries for Core, CLI, Adapters, and Extensions](../../../docs/adr/0001-governance-package-boundaries.md).


### PR DESCRIPTION
closes #186