### PR TITLE
init(governance-extension-typescript): move TypeScript-specific rules from Core to governance-extension-typescript

### DIFF
--- a/docs/governance/typescript-rule-migration.md
+++ b/docs/governance/typescript-rule-migration.md
@@ -1,0 +1,85 @@
+# TypeScript Governance Rule Migration
+
+## Purpose
+
+This document records the #238 review of current Governance Core rule
+implementations before moving TypeScript-specific rules into
+`@anarchitects/governance-extension-typescript`.
+
+The intent of #238 is architectural relocation, not redesign. Rules should move
+only when they are tied to TypeScript semantics such as `tsconfig`, imports,
+exports, path aliases, module structure, barrels, circular imports, or other
+TypeScript-specific facts.
+
+## Current Rule Inventory
+
+The current Core rule implementations live in
+`packages/governance/core/src/core/evaluation/built-in-rules.ts`.
+
+| Rule id                   | Classification | Current owner   | Reason                                                                                                                                                 |
+| ------------------------- | -------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `domain-boundary`         | Generic        | Governance Core | Evaluates declared project domains and project-to-project dependencies. It does not inspect TypeScript source, imports, `tsconfig`, or path aliases.   |
+| `layer-boundary`          | Generic        | Governance Core | Evaluates declared architectural layers and dependency direction. It is based on generic layer metadata, not TypeScript module semantics.              |
+| `ownership-presence`      | Generic        | Governance Core | Evaluates ownership metadata on governed projects. It is not tied to TypeScript extraction.                                                            |
+| `project-name-convention` | Generic        | Governance Core | Evaluates configured project naming conventions using a regular expression. The concept is generic even when TypeScript adapters provide the projects. |
+| `tag-convention`          | Generic        | Governance Core | Evaluates generic tag prefixes and values. It is not tied to TypeScript tag sources.                                                                   |
+| `missing-domain`          | Generic        | Governance Core | Evaluates whether generic domain metadata is present when configured.                                                                                  |
+| `missing-layer`           | Generic        | Governance Core | Evaluates whether generic layer metadata is present when configured.                                                                                   |
+
+## TypeScript-Specific Rules Found
+
+No existing Governance Core rule implementation is currently TypeScript-specific.
+
+The review found no Core rule implementation for:
+
+- `tsconfig` analysis.
+- import or export analysis.
+- path alias analysis.
+- barrel usage analysis.
+- circular import analysis.
+- TypeScript module structure analysis.
+- TypeScript-specific dependency interpretation.
+
+## Migration Outcome
+
+No rule implementation was moved in #238 because there is no current
+TypeScript-specific rule implementation in Governance Core.
+
+The generic Core rules remain in Core. This preserves existing behavior and
+avoids moving generic governance semantics into a technology-specific extension.
+
+`@anarchitects/governance-extension-typescript` remains the target package for
+future TypeScript-specific rules. When such rules are introduced or migrated,
+they should be registered through the Core extension contracts and must not
+depend on `@anarchitects/governance-adapter-typescript`, `@anarchitects/governance-cli`,
+or reporting internals.
+
+## Behavior Preservation
+
+Because no existing rule moved:
+
+- Existing Core rule identifiers remain unchanged.
+- Existing Core rule findings remain unchanged.
+- Existing CLI policy evaluation remains unchanged.
+- The TypeScript extension does not duplicate generic Core rule findings.
+- No adapter, CLI, reporting, or Core contract changes are required.
+
+## Remaining Responsibilities
+
+Governance Core retains:
+
+- rule contracts
+- rule engine primitives
+- generic project/dependency policy rules
+- generic metadata and ownership policy rules
+
+`@anarchitects/governance-extension-typescript` owns future:
+
+- TypeScript-specific rule implementations
+- TypeScript-specific rule registration
+- TypeScript-specific interpretation of canonical nodes, relations,
+  capabilities, and diagnostics
+
+## Follow-Up
+
+#239 remains the follow-up for TypeScript-specific metrics and recommendations.

--- a/packages/governance/extension-typescript/README.md
+++ b/packages/governance/extension-typescript/README.md
@@ -4,8 +4,8 @@ TypeScript-specific Governance extension package for the Anarchitects Community
 Governance runtime.
 
 This package establishes the package boundary and registration surface for
-future TypeScript-specific Governance interpretation. It is intentionally a
-minimal no-op extension in #237.
+TypeScript-specific Governance interpretation. #238 classified the current Core
+rule implementations and found no existing TypeScript-specific rules to move.
 
 ## Purpose
 
@@ -17,7 +17,8 @@ TypeScript-specific Governance contributions:
 - TypeScript-specific recommendations.
 - TypeScript-specific enrichers.
 
-Those contributions are not implemented in this package introduction.
+Current Core rules are generic project/dependency, metadata, ownership, and
+convention rules, so they remain in `@anarchitects/governance-core`.
 
 ## Architecture Boundary
 
@@ -53,11 +54,14 @@ The package exports:
 - `TYPESCRIPT_GOVERNANCE_EXTENSION_ID`
 
 Registration is currently a no-op. No rule packs, metric providers, signal
-providers, or enrichers are registered in #237.
+providers, or enrichers are registered because no current Core rule is
+TypeScript-specific.
 
-## Future Responsibilities
+## Rule Migration Status
 
-- #238 moves TypeScript-specific rules into this package.
+- #238 classified existing Core rule implementations.
+- No existing Core rule moved because the current built-in rules are generic.
+- Future TypeScript-specific rules should be implemented in this package.
 - #239 moves TypeScript-specific metrics and recommendations into this package.
 
 ## Non-Responsibilities

--- a/packages/governance/extension-typescript/src/extension.spec.ts
+++ b/packages/governance/extension-typescript/src/extension.spec.ts
@@ -60,7 +60,7 @@ describe('TypeScript Governance extension', () => {
     });
   });
 
-  it('registers with the Governance Core extension runtime as a no-op package boundary', async () => {
+  it('does not duplicate generic Core rules during TypeScript extension registration', async () => {
     const result = await registerLoadedGovernanceExtensionsWithDiagnostics(
       context,
       [


### PR DESCRIPTION
closes #238