### PR TITLE
feat(governance-core,governance-cli): rename remaining project-oriented profile options to node terminology

### DIFF
--- a/packages/governance/cli/src/internal/profile/load-standalone-profile.spec.ts
+++ b/packages/governance/cli/src/internal/profile/load-standalone-profile.spec.ts
@@ -127,7 +127,7 @@ describe('loadStandaloneGovernanceProfile', () => {
         },
       },
       exceptions: [],
-      projectOverrides: {},
+      nodeOverrides: {},
       profileSource: {
         boundaryPolicySource: 'profile',
       },
@@ -161,18 +161,91 @@ describe('loadStandaloneGovernanceProfile', () => {
         {
           code: 'governance.profile.unsupported_nx_runtime_profile',
           message:
-            'Nx Governance runtime profile files are not supported by the standalone CLI. Use a standalone profile with an explicit "name" field and without Nx-only override fields such as "projectOverrides", "exceptions", or legacy metric weight keys.',
+            'Nx Governance runtime profile files are not supported by the standalone CLI. Use a standalone profile with an explicit "name" field and without Nx-only override fields such as "nodeOverrides", "exceptions", or legacy metric weight keys.',
           path: '/',
         },
         {
           code: 'governance.profile.unknown_field',
-          message: 'Unknown field "projectOverrides" is not allowed.',
-          path: '/projectOverrides',
+          message: 'Unknown field "nodeOverrides" is not allowed.',
+          path: '/nodeOverrides',
         },
         {
           code: 'governance.profile.missing_required_field',
           message: 'Profile name is required.',
           path: '/name',
+        },
+      ]);
+    }
+  });
+
+  it('rejects legacy projectOverrides as an unknown field', () => {
+    expect(() =>
+      validateStandaloneGovernanceProfile({
+        name: 'legacy-overrides',
+        boundaryPolicySource: 'profile',
+        layers: ['app'],
+        allowedDomainDependencies: {
+          '*': [],
+        },
+        ownership: {
+          required: false,
+          metadataField: 'ownership',
+        },
+        health: {
+          statusThresholds: {
+            goodMinScore: 85,
+            warningMinScore: 70,
+          },
+        },
+        metrics: {
+          'architectural-entropy': 1,
+          'dependency-complexity': 1,
+          'domain-integrity': 1,
+          'ownership-coverage': 1,
+          'documentation-completeness': 1,
+          'layer-integrity': 1,
+        },
+        projectOverrides: {},
+      }),
+    ).toThrow(StandaloneGovernanceProfileValidationError);
+
+    try {
+      validateStandaloneGovernanceProfile({
+        name: 'legacy-overrides',
+        boundaryPolicySource: 'profile',
+        layers: ['app'],
+        allowedDomainDependencies: {
+          '*': [],
+        },
+        ownership: {
+          required: false,
+          metadataField: 'ownership',
+        },
+        health: {
+          statusThresholds: {
+            goodMinScore: 85,
+            warningMinScore: 70,
+          },
+        },
+        metrics: {
+          'architectural-entropy': 1,
+          'dependency-complexity': 1,
+          'domain-integrity': 1,
+          'ownership-coverage': 1,
+          'documentation-completeness': 1,
+          'layer-integrity': 1,
+        },
+        projectOverrides: {},
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(StandaloneGovernanceProfileValidationError);
+      expect(
+        (error as StandaloneGovernanceProfileValidationError).issues,
+      ).toEqual([
+        {
+          code: 'governance.profile.unknown_field',
+          message: 'Unknown field "projectOverrides" is not allowed.',
+          path: '/projectOverrides',
         },
       ]);
     }

--- a/packages/governance/cli/src/internal/profile/load-standalone-profile.ts
+++ b/packages/governance/cli/src/internal/profile/load-standalone-profile.ts
@@ -22,7 +22,7 @@ const PROFILE_TOP_LEVEL_FIELDS = new Set([
   'metrics',
 ]);
 const NX_RUNTIME_PROFILE_ONLY_FIELDS = new Set([
-  'projectOverrides',
+  'nodeOverrides',
   'exceptions',
   'eslint',
 ]);
@@ -218,7 +218,7 @@ function detectUnsupportedNxRuntimeProfile(
   return {
     code: 'governance.profile.unsupported_nx_runtime_profile',
     message:
-      'Nx Governance runtime profile files are not supported by the standalone CLI. Use a standalone profile with an explicit "name" field and without Nx-only override fields such as "projectOverrides", "exceptions", or legacy metric weight keys.',
+      'Nx Governance runtime profile files are not supported by the standalone CLI. Use a standalone profile with an explicit "name" field and without Nx-only override fields such as "nodeOverrides", "exceptions", or legacy metric weight keys.',
     path: '/',
   };
 }

--- a/packages/governance/cli/tests/fixtures/nx-runtime-profile/frontend-layered.json
+++ b/packages/governance/cli/tests/fixtures/nx-runtime-profile/frontend-layered.json
@@ -24,7 +24,7 @@
     "documentationCompletenessWeight": 0.2,
     "layerIntegrityWeight": 0.2
   },
-  "projectOverrides": {
+  "nodeOverrides": {
     "@anarchitecture-plugins/source": {
       "documentation": true
     },

--- a/packages/governance/core/src/core/adapter/adapter.ts
+++ b/packages/governance/core/src/core/adapter/adapter.ts
@@ -214,7 +214,7 @@ export interface GovernanceDiagnostic {
 
 export function buildGovernanceWorkspace(
   adapterResult: GovernanceWorkspaceAdapterResult,
-  _overrides: ProfileOverrides = { projectOverrides: {} },
+  _overrides: ProfileOverrides = { nodeOverrides: {} },
 ): GovernanceWorkspace {
   const graph = buildGovernanceNormalizedGraph(adapterResult);
   const root =

--- a/packages/governance/core/src/core/evaluation/built-in-rules.ts
+++ b/packages/governance/core/src/core/evaluation/built-in-rules.ts
@@ -9,7 +9,7 @@ import {
   normalizeGovernanceProfile,
   type MissingDomainOptions,
   type MissingLayerOptions,
-  type ProjectNameConventionOptions,
+  type NodeNameConventionOptions,
   type TagConventionOptions,
   type GovernanceDomainBoundaryRuleOptions,
   type GovernanceLayerBoundaryRuleOptions,
@@ -159,7 +159,7 @@ export const projectNameConventionRule: SynchronousGovernanceRule = {
     const normalizedProfile = normalizeGovernanceProfile(profile);
     const ruleConfig = normalizedProfile.rules[projectNameConventionRule.id];
     const options = ruleConfig?.options as
-      | ProjectNameConventionOptions
+      | NodeNameConventionOptions
       | undefined;
 
     if (!ruleConfig?.enabled || !options?.pattern) {
@@ -583,7 +583,7 @@ function evaluateOwnershipPresence(
 
 function evaluateNodeNameConvention(
   node: GovernanceNode,
-  options: ProjectNameConventionOptions,
+  options: NodeNameConventionOptions,
   pattern: RegExp,
   severity: Violation['severity'],
 ): Violation[] {

--- a/packages/governance/core/src/core/evaluation/profile.spec.ts
+++ b/packages/governance/core/src/core/evaluation/profile.spec.ts
@@ -104,7 +104,7 @@ describe('normalizeGovernanceProfile', () => {
     });
   });
 
-  it('preserves exceptions and project overrides from compatibility inputs', () => {
+  it('preserves exceptions and node overrides', () => {
     const exceptions: GovernanceException[] = [
       {
         id: 'policy-exception',
@@ -122,7 +122,7 @@ describe('normalizeGovernanceProfile', () => {
         },
       },
     ];
-    const projectOverrides: Record<string, GovernanceNodeOverride> = {
+    const nodeOverrides: Record<string, GovernanceNodeOverride> = {
       'booking-feature': {
         domain: 'booking',
         documentation: true,
@@ -131,10 +131,10 @@ describe('normalizeGovernanceProfile', () => {
 
     const normalized = normalizeGovernanceProfile(baseProfile, {
       exceptions,
-      projectOverrides,
+      nodeOverrides,
     });
 
     expect(normalized.exceptions).toEqual(exceptions);
-    expect(normalized.projectOverrides).toEqual(projectOverrides);
+    expect(normalized.nodeOverrides).toEqual(nodeOverrides);
   });
 });

--- a/packages/governance/core/src/core/evaluation/profile.ts
+++ b/packages/governance/core/src/core/evaluation/profile.ts
@@ -67,12 +67,12 @@ export interface GovernanceProfileSourceMetadata {
   boundaryPolicySource: GovernanceProfile['boundaryPolicySource'];
 }
 
-export interface ProjectNameConventionOptions {
+export interface NodeNameConventionOptions {
   pattern: string;
   message?: string;
 }
 
-export interface ProjectRootConventionOptions {
+export interface NodeRootConventionOptions {
   patterns: string[];
   message?: string;
   requireRoot?: boolean;
@@ -108,7 +108,7 @@ export interface NormalizedGovernanceProfile {
   rules: Record<string, GovernanceRuleConfig>;
   scoring: GovernanceScoringProfile;
   exceptions: GovernanceException[];
-  projectOverrides: Record<string, GovernanceNodeOverride>;
+  nodeOverrides: Record<string, GovernanceNodeOverride>;
   profileSource: GovernanceProfileSourceMetadata;
 }
 
@@ -124,7 +124,7 @@ export interface ProfileOverrides {
   };
   metrics?: Partial<Record<string, number>>;
   exceptions?: GovernanceException[];
-  projectOverrides: Record<string, GovernanceNodeOverride>;
+  nodeOverrides: Record<string, GovernanceNodeOverride>;
 }
 
 export function deriveAllowedLayerDependenciesFromLayerOrder(
@@ -137,9 +137,7 @@ export function deriveAllowedLayerDependenciesFromLayerOrder(
 
 export function normalizeGovernanceProfile(
   profile: GovernanceProfile,
-  options: Partial<
-    Pick<ProfileOverrides, 'exceptions' | 'projectOverrides'>
-  > = {},
+  options: Partial<Pick<ProfileOverrides, 'exceptions' | 'nodeOverrides'>> = {},
 ): NormalizedGovernanceProfile {
   const allowedLayerDependencies =
     profile.allowedLayerDependencies ??
@@ -198,7 +196,7 @@ export function normalizeGovernanceProfile(
       metricWeights: profile.metrics,
     },
     exceptions: options.exceptions ?? [],
-    projectOverrides: options.projectOverrides ?? {},
+    nodeOverrides: options.nodeOverrides ?? {},
     profileSource: {
       boundaryPolicySource: profile.boundaryPolicySource,
     },


### PR DESCRIPTION
closes #329