### PR TITLE
feat(governance-core,governance-cli): add opt-in Top Signals view for info-level telemetry

### DIFF
--- a/packages/governance/cli/README.md
+++ b/packages/governance/cli/README.md
@@ -109,7 +109,13 @@ import {
 ```bash
 agov assess --workspace ./governance.workspace.json --profile ./governance.profile.json
 agov check --workspace ./governance.workspace.json --profile ./governance.profile.json
+agov assess --workspace ./governance.workspace.json --profile ./governance.profile.json --include-top-signals
 ```
+
+`Top Issues` stays focused on actionable `warning` and `error` findings. Use
+`agov assess --include-top-signals` when you want a separate `Top Signals`
+section that can include `info`-level telemetry for architecture inspection or
+debugging.
 
 ### Inspection Commands
 

--- a/packages/governance/cli/src/agov.spec.ts
+++ b/packages/governance/cli/src/agov.spec.ts
@@ -74,6 +74,7 @@ describe('agov executable command surface', () => {
     expect(io.out).toContain('agov assess');
     expect(io.out).toContain('--config <path>');
     expect(io.out).toContain('--adapter <package>');
+    expect(io.out).toContain('--include-top-signals');
     expect(io.err).toBe('');
   });
 
@@ -1757,6 +1758,48 @@ describe('agov executable command surface', () => {
     expect(JSON.parse(io.out)).toMatchObject({
       command: 'assess',
       success: true,
+    });
+  });
+
+  it('supports opt-in top signals in assess output', async () => {
+    const io = createMemoryIo();
+    const cwd = createTempWorkspaceRoot('agov-assess-top-signals-');
+
+    writeFixtureWorkspace(path.join(cwd, 'workspace.json'));
+    writeFailingFixtureProfile(path.join(cwd, 'profile.json'));
+
+    expect(
+      await runAgovCli(
+        [
+          'assess',
+          '--workspace',
+          './workspace.json',
+          '--profile',
+          './profile.json',
+          '--include-top-signals',
+          '--format',
+          'json',
+        ],
+        io,
+        undefined,
+        createEnvironment({ cwd }),
+      ),
+    ).toBe(AGOV_EXIT_GOVERNANCE_FAILURE);
+
+    expect(JSON.parse(io.out)).toMatchObject({
+      command: 'assess',
+      success: false,
+      assessment: {
+        topIssues: [
+          expect.objectContaining({ severity: 'error' }),
+          expect.objectContaining({ severity: 'warning' }),
+        ],
+        topSignals: [
+          expect.objectContaining({ severity: 'info' }),
+          expect.objectContaining({ severity: 'warning' }),
+          expect.objectContaining({ severity: 'error' }),
+        ],
+      },
     });
   });
 

--- a/packages/governance/cli/src/agov.ts
+++ b/packages/governance/cli/src/agov.ts
@@ -211,6 +211,7 @@ export type ParsedAgovCheckOptions = ParsedAgovAssessmentOptions & {
 
 export type ParsedAgovAssessOptions = ParsedAgovAssessmentOptions & {
   command: 'assess';
+  includeTopSignals?: boolean;
 };
 
 export type ParsedAgovMetricsOptions = ParsedAgovAssessmentOptions & {
@@ -312,6 +313,7 @@ export type AgovResolvedCheckCommand = AgovResolvedAssessmentCommand & {
 
 export type AgovResolvedAssessCommand = AgovResolvedAssessmentCommand & {
   command: 'assess';
+  includeTopSignals?: boolean;
 };
 
 export type AgovResolvedMetricsCommand = AgovResolvedAssessmentCommand & {
@@ -402,7 +404,7 @@ export interface AgovResolvedWorkspaceValidateCommand {
 }
 
 export type AgovAssessmentRuntimeOptions<TInput = unknown> =
-  AgovCheckOptions<TInput>;
+  AgovAssessOptions<TInput>;
 
 export const AGOV_EXIT_SUCCESS = 0;
 export const AGOV_EXIT_GOVERNANCE_FAILURE = 1;
@@ -1511,6 +1513,7 @@ function parseAgovAssessmentArgs(
   let rootPath: string | undefined;
   let format: AgovOutputFormat | undefined;
   let outputPath: string | undefined;
+  let includeTopSignals: boolean | undefined;
   let showHelp = false;
 
   for (let index = 0; index < args.length; index += 1) {
@@ -1577,6 +1580,11 @@ function parseAgovAssessmentArgs(
       continue;
     }
 
+    if (command === 'assess' && arg === '--include-top-signals') {
+      includeTopSignals = true;
+      continue;
+    }
+
     if (
       command === 'metrics' &&
       (arg === '--family' || arg === '--metric' || arg === '--weakest')
@@ -1625,6 +1633,7 @@ function parseAgovAssessmentArgs(
     rootPath,
     format,
     outputPath,
+    ...(command === 'assess' && includeTopSignals ? { includeTopSignals } : {}),
     showHelp,
   };
 }
@@ -1657,7 +1666,14 @@ export function resolveAgovAssessCommand(
   options: ParsedAgovAssessOptions,
   environment: Pick<AgovCliEnvironment, 'cwd'>,
 ): AgovResolvedAssessCommand {
-  return resolveAgovAssessmentCommand(options, environment);
+  const resolved = resolveAgovAssessmentCommand(options, environment);
+  return {
+    ...resolved,
+    command: 'assess',
+    ...(options.includeTopSignals
+      ? { includeTopSignals: options.includeTopSignals }
+      : {}),
+  };
 }
 
 export function resolveAgovMetricsCommand(
@@ -1849,6 +1865,9 @@ export function resolveAgovAssessmentCommand(
     ...resolved,
     command: options.command,
     profilePath,
+    ...('includeTopSignals' in options && options.includeTopSignals
+      ? { includeTopSignals: options.includeTopSignals }
+      : {}),
   };
 }
 
@@ -2098,6 +2117,9 @@ export async function resolveAgovRuntimeOptions(
       return {
         profilePath: command.profilePath,
         workspacePath: command.workspacePath,
+        ...(command.command === 'assess' && command.includeTopSignals
+          ? { includeTopSignals: command.includeTopSignals }
+          : {}),
         ...('filters' in command && command.filters
           ? { filters: command.filters }
           : {}),
@@ -2122,6 +2144,9 @@ export async function resolveAgovRuntimeOptions(
         profilePath: command.profilePath,
         workspaceAdapter: resolvedAdapter.adapter,
         workspaceAdapterInput: command.rootPath,
+        ...(command.command === 'assess' && command.includeTopSignals
+          ? { includeTopSignals: command.includeTopSignals }
+          : {}),
         ...(await loadInferredGovernanceExtensions(
           resolvedAdapter.packageName,
           environment,
@@ -2142,6 +2167,9 @@ export async function resolveAgovRuntimeOptions(
       profilePath: command.profilePath,
       workspaceAdapter,
       workspaceAdapterInput: command.rootPath,
+      ...(command.command === 'assess' && command.includeTopSignals
+        ? { includeTopSignals: command.includeTopSignals }
+        : {}),
       ...(await loadInferredGovernanceExtensions(
         command.adapterPackage,
         environment,
@@ -2908,6 +2936,7 @@ function renderAgovAssessHelp(): string {
     '  --adapter <package> Dynamically load a concrete adapter package.',
     '  --root <path>       Adapter input root. Defaults to the current working directory.',
     '  --format <value>    Output format: table, markdown, text, or json. Defaults to text.',
+    '  --include-top-signals Render a separate Top Signals section including info-level telemetry.',
     '  --output <path>     Write command output to a file instead of stdout.',
     '',
     'Conventions:',

--- a/packages/governance/cli/src/check.ts
+++ b/packages/governance/cli/src/check.ts
@@ -3,6 +3,10 @@ import type {
   GovernanceAssessmentArtifacts,
   GovernanceExtensionDiagnostic,
   GovernanceLoadedExtension,
+  GovernanceSignal,
+  GovernanceSignalSeverity,
+  GovernanceSignalSource,
+  GovernanceTopSignal,
   GovernanceWorkspaceAdapter,
   GovernanceWorkspaceAdapterResult,
 } from '@anarchitects/governance-core';
@@ -10,7 +14,22 @@ import * as governanceCore from '@anarchitects/governance-core';
 import { loadGenericWorkspaceAdapterResult } from './internal/manual-workspace/load-workspace.js';
 import { loadStandaloneGovernanceProfile } from './internal/profile/load-standalone-profile.js';
 
-type GovernanceGraph = ReturnType<typeof governanceCore.normalizeGovernanceGraph>;
+type GovernanceGraph = ReturnType<
+  typeof governanceCore.normalizeGovernanceGraph
+>;
+
+const TOP_SIGNAL_SOURCE_ORDER: Record<GovernanceSignalSource, number> = {
+  graph: 0,
+  conformance: 1,
+  policy: 2,
+  extension: 3,
+};
+
+const TOP_SIGNAL_SEVERITY_ORDER: Record<GovernanceSignalSeverity, number> = {
+  info: 0,
+  warning: 1,
+  error: 2,
+};
 
 export interface AgovCheckWithWorkspacePathOptions {
   profilePath: string;
@@ -34,7 +53,9 @@ export type AgovCheckOptions<TInput = unknown> =
   | AgovCheckWithWorkspacePathOptions
   | AgovCheckWithAdapterOptions<TInput>;
 
-export type AgovAssessOptions<TInput = unknown> = AgovCheckOptions<TInput>;
+export type AgovAssessOptions<TInput = unknown> = AgovCheckOptions<TInput> & {
+  includeTopSignals?: boolean;
+};
 
 export interface AgovCheckResult {
   command: 'check';
@@ -109,6 +130,7 @@ export async function runAgovAssess<TInput = unknown>(
   return governanceCore
     .buildGovernanceAssessmentArtifacts({
       profile,
+      includeTopSignals: options.includeTopSignals,
       workspace,
       capabilities,
       diagnostics,
@@ -116,15 +138,22 @@ export async function runAgovAssess<TInput = unknown>(
       extensionContext,
       extensionDiagnostics: extensionRegistration.diagnostics,
     })
-    .then((artifacts) => ({
-      command: 'assess',
-      success: !artifacts.assessment.violations.some(
-        (violation) => violation.severity === 'error',
-      ),
-      assessment: artifacts.assessment,
-      artifacts,
-      graph,
-    }));
+    .then((artifacts) => {
+      const assessment = normalizeAssessmentTopSignals(artifacts, options);
+
+      return {
+        command: 'assess',
+        success: !assessment.violations.some(
+          (violation) => violation.severity === 'error',
+        ),
+        assessment,
+        artifacts:
+          assessment === artifacts.assessment
+            ? artifacts
+            : { ...artifacts, assessment },
+        graph,
+      };
+    });
 }
 
 function resolveWorkspaceAdapterResult<TInput>(
@@ -144,9 +173,120 @@ function buildExtensionOptions<TInput>(
 ): Readonly<Record<string, unknown>> {
   return {
     profilePath: options.profilePath,
+    ...(options.includeTopSignals
+      ? { includeTopSignals: options.includeTopSignals }
+      : {}),
     ...(options.workspacePath ? { workspacePath: options.workspacePath } : {}),
     ...('workspaceAdapter' in options && options.workspaceAdapter
       ? { workspaceAdapterId: options.workspaceAdapter.id }
       : {}),
   };
+}
+
+function normalizeAssessmentTopSignals<TInput>(
+  artifacts: GovernanceAssessmentArtifacts,
+  options: AgovAssessOptions<TInput>,
+): GovernanceAssessment {
+  if (!options.includeTopSignals || artifacts.assessment.topSignals) {
+    return artifacts.assessment;
+  }
+
+  return {
+    ...artifacts.assessment,
+    topSignals: buildFallbackTopSignals(artifacts.signals),
+  };
+}
+
+function buildFallbackTopSignals(
+  signals: GovernanceSignal[],
+): GovernanceTopSignal[] {
+  const groups = new Map<string, GovernanceTopSignal>();
+
+  for (const signal of signals) {
+    const key = [
+      signal.type,
+      signal.source,
+      signal.severity,
+      signal.nodeId ?? '',
+      signal.relationId ?? '',
+      (signal.relatedNodeIds ?? []).join(','),
+      (signal.relatedRelationIds ?? []).join(','),
+    ].join('|');
+    const existing = groups.get(key);
+
+    if (existing) {
+      existing.count += 1;
+      existing.subjects = [
+        ...new Set([...existing.subjects, ...subjectsFromSignal(signal)]),
+      ].sort((left, right) => left.localeCompare(right));
+      if (!existing.ruleId) {
+        existing.ruleId = readRuleId(signal);
+      }
+      if (!existing.sourcePluginId) {
+        existing.sourcePluginId = signal.sourcePluginId;
+      }
+      continue;
+    }
+
+    groups.set(key, {
+      type: signal.type,
+      source: signal.source,
+      severity: signal.severity,
+      count: 1,
+      subjects: subjectsFromSignal(signal),
+      ruleId: readRuleId(signal),
+      message: signal.message,
+      sourcePluginId: signal.sourcePluginId,
+    });
+  }
+
+  return [...groups.values()].sort(
+    (left: GovernanceTopSignal, right: GovernanceTopSignal) => {
+    const sourceOrder =
+      TOP_SIGNAL_SOURCE_ORDER[left.source] -
+      TOP_SIGNAL_SOURCE_ORDER[right.source];
+    if (sourceOrder !== 0) {
+      return sourceOrder;
+    }
+
+    const severityOrder =
+      TOP_SIGNAL_SEVERITY_ORDER[left.severity] -
+      TOP_SIGNAL_SEVERITY_ORDER[right.severity];
+    if (severityOrder !== 0) {
+      return severityOrder;
+    }
+
+    const typeOrder = left.type.localeCompare(right.type);
+    if (typeOrder !== 0) {
+      return typeOrder;
+    }
+
+    const subjectsOrder = left.subjects
+      .join(',')
+      .localeCompare(right.subjects.join(','));
+    if (subjectsOrder !== 0) {
+      return subjectsOrder;
+    }
+
+      return left.message.localeCompare(right.message);
+    },
+  );
+}
+
+function subjectsFromSignal(signal: GovernanceSignal): string[] {
+  return [
+    ...new Set(
+      [
+        signal.nodeId,
+        signal.relationId,
+        ...(signal.relatedNodeIds ?? []),
+        ...(signal.relatedRelationIds ?? []),
+      ].filter((value): value is string => Boolean(value)),
+    ),
+  ].sort((left, right) => left.localeCompare(right));
+}
+
+function readRuleId(signal: GovernanceSignal): string | undefined {
+  const ruleId = signal.metadata?.ruleId;
+  return typeof ruleId === 'string' && ruleId.length > 0 ? ruleId : undefined;
 }

--- a/packages/governance/cli/src/internal/reporting/render-cli.ts
+++ b/packages/governance/cli/src/internal/reporting/render-cli.ts
@@ -4,6 +4,7 @@ import type {
 } from '@anarchitects/governance-core';
 
 const TOP_ISSUES_LIMIT = 10;
+const TOP_SIGNALS_LIMIT = 10;
 
 export function renderCliReport(assessment: GovernanceAssessment): string {
   const lines: string[] = [];
@@ -166,6 +167,21 @@ export function renderCliReport(assessment: GovernanceAssessment): string {
           : '';
       lines.push(
         `- [${issue.severity}] ${issue.type} (${issue.source}) x${issue.count}${ruleIdSuffix}${subjectsSuffix} :: ${issue.message}`,
+      );
+    }
+  }
+
+  if (assessment.topSignals && assessment.topSignals.length > 0) {
+    lines.push('');
+    lines.push('Top Signals:');
+    for (const signal of assessment.topSignals.slice(0, TOP_SIGNALS_LIMIT)) {
+      const ruleIdSuffix = signal.ruleId ? ` :: ${signal.ruleId}` : '';
+      const subjectsSuffix =
+        signal.subjects.length > 0
+          ? ` :: subjects=${signal.subjects.join(',')}`
+          : '';
+      lines.push(
+        `- [${signal.severity}] ${signal.type} (${signal.source}) x${signal.count}${ruleIdSuffix}${subjectsSuffix} :: ${signal.message}`,
       );
     }
   }

--- a/packages/governance/cli/src/render-report.spec.ts
+++ b/packages/governance/cli/src/render-report.spec.ts
@@ -112,6 +112,7 @@ describe('agov command report rendering', () => {
         extensionDiagnostics: expect.any(Array),
       },
     });
+    expect(parsed.assessment).not.toHaveProperty('topSignals');
   });
 
   it('delegates low-level formatting to shared primitives', async () => {
@@ -157,6 +158,60 @@ describe('agov command report rendering', () => {
     const tableRendered = renderAgovCheckReport(assessResult, 'table');
 
     expect(textRendered).toBe(tableRendered);
+  });
+
+  it('keeps top signals out of default assess rendering', async () => {
+    const assessResult = await runAgovAssess({
+      workspacePath: fixturePath(
+        '../tests/fixtures/manual-workspace/demo-workspace.json',
+      ),
+      profilePath: fixturePath(
+        '../tests/fixtures/standalone-cli/passing-profile.json',
+      ),
+    });
+
+    const textRendered = renderAgovCheckReport(assessResult, 'text');
+
+    expect(assessResult.assessment.topIssues).toEqual([]);
+    expect(assessResult.assessment).not.toHaveProperty('topSignals');
+    expect(textRendered).not.toContain('Top Signals:');
+  });
+
+  it('renders opt-in top signals as a separate section and JSON field', async () => {
+    const assessResult = await runAgovAssess({
+      workspacePath: fixturePath(
+        '../tests/fixtures/manual-workspace/demo-workspace.json',
+      ),
+      profilePath: fixturePath(
+        '../tests/fixtures/standalone-cli/error-profile.json',
+      ),
+      includeTopSignals: true,
+    });
+
+    const parsed = JSON.parse(renderAgovCheckJson(assessResult)) as {
+      assessment: {
+        topIssues: Array<{ type: string; severity: string }>;
+        topSignals?: Array<{ type: string; severity: string }>;
+      };
+    };
+    const textRendered = renderAgovCheckReport(assessResult, 'text');
+
+    expect(parsed.assessment.topIssues.map((issue) => issue.severity)).toEqual([
+      'error',
+      'warning',
+    ]);
+    expect(
+      parsed.assessment.topSignals?.map(
+        (signal) => `${signal.severity}:${signal.type}`,
+      ),
+    ).toEqual([
+      'info:structural-dependency',
+      'warning:cross-domain-dependency',
+      'error:domain-boundary-violation',
+    ]);
+    expect(textRendered).toContain('Top Signals:');
+    expect(textRendered).toContain('[info] structural-dependency');
+    expect(textRendered).toContain('Top Issues:');
   });
 
   it('renders canonical diagnostics in JSON and text outputs', async () => {

--- a/packages/governance/core/src/core/evaluation/assessment-artifacts.spec.ts
+++ b/packages/governance/core/src/core/evaluation/assessment-artifacts.spec.ts
@@ -100,6 +100,43 @@ describe('assessment artifact assembly', () => {
     expect(artifacts.assessment.topIssues).toEqual([]);
   });
 
+  it('includes top signals only when explicitly requested', async () => {
+    const artifacts = await buildGovernanceAssessmentArtifacts({
+      workspace: createWorkspace(
+        [
+          createNode('booking-domain', 'booking'),
+          createNode('shared-kernel', 'shared'),
+        ],
+        [
+          createDependencyRelation(
+            'relation:booking-domain->shared-kernel',
+            'booking-domain',
+            'shared-kernel',
+          ),
+        ],
+      ),
+      profile: {
+        ...testProfile,
+        allowedDomainDependencies: {
+          booking: ['shared'],
+          shared: [],
+        },
+        ownership: {
+          required: false,
+          metadataField: 'ownership',
+        },
+      },
+      includeTopSignals: true,
+      exceptions: [],
+      asOf: new Date('2026-05-23'),
+    });
+
+    expect(artifacts.assessment.topIssues).toEqual([]);
+    expect(
+      artifacts.assessment.topSignals?.map((signal) => signal.type),
+    ).toEqual(['structural-dependency']);
+  });
+
   it('keeps violations, signals, and assessment aligned for disallowed cross-domain dependencies', async () => {
     const artifacts = await buildGovernanceAssessmentArtifacts({
       workspace: createWorkspace(

--- a/packages/governance/core/src/core/evaluation/assessment-artifacts.ts
+++ b/packages/governance/core/src/core/evaluation/assessment-artifacts.ts
@@ -53,6 +53,7 @@ import type { GovernanceSignal } from './signals.js';
 
 export interface BuildGovernanceAssessmentArtifactsInput {
   profile: GovernanceProfile;
+  includeTopSignals?: boolean;
   workspaceAdapterResult?: GovernanceWorkspaceAdapterResult;
   workspace?: GovernanceWorkspace;
   warnings?: string[];
@@ -195,6 +196,7 @@ export async function buildGovernanceAssessmentArtifacts(
     workspace: enrichedWorkspace,
     profile: input.profile.name,
     warnings: input.warnings ?? [],
+    includeTopSignals: input.includeTopSignals,
     exceptions:
       input.exceptions && input.exceptions.length > 0
         ? buildGovernanceExceptionReport(exceptionApplication)

--- a/packages/governance/core/src/core/evaluation/assessment.spec.ts
+++ b/packages/governance/core/src/core/evaluation/assessment.spec.ts
@@ -1,6 +1,7 @@
 import {
   buildGovernanceAssessment,
   buildTopIssues,
+  buildTopSignals,
   type GovernanceAssessment,
   type GovernanceSignal,
   type HealthScore,
@@ -184,6 +185,7 @@ describe('buildGovernanceAssessment', () => {
       'domain-boundary-violation',
       'ownership-gap',
     ]);
+    expect(assessment).not.toHaveProperty('topSignals');
     expect(
       JSON.parse(JSON.stringify(assessment)) as GovernanceAssessment,
     ).toEqual(assessment);
@@ -217,6 +219,23 @@ describe('buildGovernanceAssessment', () => {
     });
 
     expect(assessment.topIssues).toEqual([]);
+  });
+
+  it('includes top signals only when explicitly requested', () => {
+    const assessment = buildGovernanceAssessment({
+      ...baseAssessmentInput,
+      includeTopSignals: true,
+    });
+
+    expect(assessment.topIssues.map((issue) => issue.type)).toEqual([
+      'domain-boundary-violation',
+      'ownership-gap',
+    ]);
+    expect(assessment.topSignals?.map((signal) => signal.type)).toEqual([
+      'structural-dependency',
+      'ownership-gap',
+      'domain-boundary-violation',
+    ]);
   });
 });
 
@@ -330,6 +349,77 @@ describe('buildTopIssues', () => {
       'domain-boundary-violation',
       'cross-domain-dependency',
       'missing-domain-context',
+    ]);
+  });
+});
+
+describe('buildTopSignals', () => {
+  function createSignal(
+    overrides: Partial<GovernanceSignal> = {},
+  ): GovernanceSignal {
+    return {
+      id: 'signal',
+      type: 'structural-dependency',
+      nodeId: 'booking-ui',
+      relatedNodeIds: ['booking-ui', 'platform-shell'],
+      severity: 'info',
+      category: 'dependency',
+      message: 'Dependency: booking-ui -> platform-shell.',
+      source: 'graph',
+      createdAt: '2026-05-13T09:02:00.000Z',
+      ...overrides,
+    };
+  }
+
+  it('includes info-level telemetry when requested', () => {
+    expect(
+      buildTopSignals([
+        createSignal(),
+        createSignal({
+          id: 'warning-signal',
+          type: 'cross-domain-dependency',
+          severity: 'warning',
+          category: 'boundary',
+          message: 'Cross-domain dependency.',
+        }),
+      ]).map((signal) => signal.severity),
+    ).toEqual(['info', 'warning']);
+  });
+
+  it('keeps deterministic ordering across info, warning, and error signals', () => {
+    expect(
+      buildTopSignals([
+        createSignal({
+          id: 'error-signal',
+          type: 'domain-boundary-violation',
+          severity: 'error',
+          category: 'boundary',
+          source: 'policy',
+          message: 'Policy boundary violation.',
+        }),
+        createSignal({
+          id: 'warning-signal',
+          type: 'cross-domain-dependency',
+          severity: 'warning',
+          category: 'boundary',
+          message: 'Cross-domain dependency.',
+        }),
+        createSignal({
+          id: 'info-signal-b',
+          nodeId: 'booking-domain',
+          relatedNodeIds: ['booking-domain', 'shared-kernel'],
+          message: 'Dependency: booking-domain -> shared-kernel.',
+        }),
+        createSignal({
+          id: 'info-signal-a',
+          message: 'Dependency: booking-ui -> platform-shell.',
+        }),
+      ]).map((signal) => `${signal.source}:${signal.severity}:${signal.type}`),
+    ).toEqual([
+      'graph:info:structural-dependency',
+      'graph:info:structural-dependency',
+      'graph:warning:cross-domain-dependency',
+      'policy:error:domain-boundary-violation',
     ]);
   });
 });

--- a/packages/governance/core/src/core/evaluation/assessment.ts
+++ b/packages/governance/core/src/core/evaluation/assessment.ts
@@ -3,6 +3,7 @@ import type {
   GovernanceExceptionReport,
   GovernanceMetricFamily,
   GovernanceTopIssue,
+  GovernanceTopSignal,
   Measurement,
   MetricBreakdown,
   Recommendation,
@@ -28,6 +29,7 @@ export type GovernanceAssessmentReportType =
 export interface GovernanceAssessmentInput {
   workspace: GovernanceWorkspace;
   profile: string;
+  includeTopSignals?: boolean;
   warnings?: string[];
   exceptions: GovernanceExceptionReport;
   violations: Violation[];
@@ -106,6 +108,12 @@ const TOP_ISSUE_SEVERITY_ORDER: Record<GovernanceSignalSeverity, number> = {
   info: 2,
 };
 
+const TOP_SIGNAL_SEVERITY_ORDER: Record<GovernanceSignalSeverity, number> = {
+  info: 0,
+  warning: 1,
+  error: 2,
+};
+
 interface TopIssueGroup {
   issue: GovernanceTopIssue;
 }
@@ -141,6 +149,9 @@ export function buildGovernanceAssessment(
     signalBreakdown: buildSignalBreakdown(filteredSignals),
     metricBreakdown: buildMetricBreakdown(filteredMeasurements),
     topIssues: buildTopIssues(filteredSignals),
+    ...(input.includeTopSignals
+      ? { topSignals: buildTopSignals(filteredSignals) }
+      : {}),
     health: input.health,
     recommendations: [...(input.recommendations ?? [])],
     ...(input.metadata ? { metadata: { ...input.metadata } } : {}),
@@ -311,10 +322,23 @@ export function buildMetricBreakdown(
 export function buildTopIssues(
   signals: GovernanceSignal[],
 ): GovernanceTopIssue[] {
+  return buildTopSignalGroups(signals, isTopIssueSignal).sort(compareTopIssues);
+}
+
+export function buildTopSignals(
+  signals: GovernanceSignal[],
+): GovernanceTopSignal[] {
+  return buildTopSignalGroups(signals).sort(compareTopSignals);
+}
+
+function buildTopSignalGroups(
+  signals: GovernanceSignal[],
+  predicate?: (signal: GovernanceSignal) => boolean,
+): GovernanceTopSignal[] {
   const groups = new Map<string, TopIssueGroup>();
 
   for (const signal of signals) {
-    if (!isTopIssueSignal(signal)) {
+    if (predicate && !predicate(signal)) {
       continue;
     }
 
@@ -347,9 +371,7 @@ export function buildTopIssues(
     });
   }
 
-  return [...groups.values()]
-    .map((group) => group.issue)
-    .sort(compareTopIssues);
+  return [...groups.values()].map((group) => group.issue);
 }
 
 function isTopIssueSignal(signal: GovernanceSignal): boolean {
@@ -434,6 +456,38 @@ function compareTopIssues(
     TOP_ISSUE_SOURCE_ORDER[a.source] - TOP_ISSUE_SOURCE_ORDER[b.source];
   if (sourceOrder !== 0) {
     return sourceOrder;
+  }
+
+  const subjectsOrder = a.subjects
+    .join(',')
+    .localeCompare(b.subjects.join(','));
+  if (subjectsOrder !== 0) {
+    return subjectsOrder;
+  }
+
+  return a.message.localeCompare(b.message);
+}
+
+function compareTopSignals(
+  a: GovernanceTopSignal,
+  b: GovernanceTopSignal,
+): number {
+  const sourceOrder =
+    TOP_ISSUE_SOURCE_ORDER[a.source] - TOP_ISSUE_SOURCE_ORDER[b.source];
+  if (sourceOrder !== 0) {
+    return sourceOrder;
+  }
+
+  const severityOrder =
+    TOP_SIGNAL_SEVERITY_ORDER[a.severity] -
+    TOP_SIGNAL_SEVERITY_ORDER[b.severity];
+  if (severityOrder !== 0) {
+    return severityOrder;
+  }
+
+  const typeOrder = a.type.localeCompare(b.type);
+  if (typeOrder !== 0) {
+    return typeOrder;
   }
 
   const subjectsOrder = a.subjects

--- a/packages/governance/core/src/core/model/index.ts
+++ b/packages/governance/core/src/core/model/index.ts
@@ -21,6 +21,7 @@ export type {
   GovernanceRuntimeReference,
   GovernanceScore,
   GovernanceTopIssue,
+  GovernanceTopSignal,
   GovernanceWorkspace,
   HealthExplainability,
   HealthMetricHotspot,

--- a/packages/governance/core/src/core/model/models.ts
+++ b/packages/governance/core/src/core/model/models.ts
@@ -272,6 +272,8 @@ export interface GovernanceTopIssue {
   sourcePluginId?: string;
 }
 
+export type GovernanceTopSignal = GovernanceTopIssue;
+
 export interface GovernanceExceptionSummary {
   declaredCount: number;
   matchedCount: number;
@@ -341,6 +343,7 @@ export interface GovernanceAssessment {
   signalBreakdown: SignalBreakdown;
   metricBreakdown: MetricBreakdown;
   topIssues: GovernanceTopIssue[];
+  topSignals?: GovernanceTopSignal[];
   health: HealthScore;
   recommendations: Recommendation[];
   metadata?: Record<string, unknown>;


### PR DESCRIPTION
closes #337