### PR TITLE
refactor(governance-adapter-typescript,governance-extension-typescript): align TypeScript normalization with governance boundaries

### DIFF
--- a/packages/governance/adapter-typescript/README.md
+++ b/packages/governance/adapter-typescript/README.md
@@ -13,7 +13,8 @@ JavaScript, or mixed monorepo without depending on a framework-specific project
 graph.
 
 Package boundaries follow
-[ADR 0001](../../../docs/adr/0001-governance-package-boundaries.md).
+[ADR 0001](../../../docs/adr/0001-governance-package-boundaries.md) and
+[ADR 0003](../../../docs/adr/0003-governance-core-adapter-extension-host-boundaries.md).
 
 ## Key Concepts
 
@@ -52,7 +53,7 @@ if (probe.supported) {
 
   console.log(result.nodes);
   console.log(result.relations);
-  console.log(result.metadata);
+  console.log(result.extensions);
 }
 ```
 
@@ -85,10 +86,22 @@ The adapter emits:
 - `GovernanceWorkspaceAdapterResult.relations`
 - `GovernanceWorkspaceAdapterResult.capabilities`
 - `GovernanceWorkspaceAdapterResult.diagnostics`
-- `GovernanceWorkspaceAdapterResult.metadata`
+- `GovernanceWorkspaceAdapterResult.extensions`
 
-TypeScript and package-manager details stay under namespaced metadata such as
-`metadata.typescript` and `metadata.packageManager`.
+Canonical governance facts are emitted as first-class Core fields when they are
+genuinely generic:
+
+- `classification.domain`
+- `classification.layer`
+- `classification.scope`
+- `ownership`
+- canonical node and relation kinds such as `project`, `resource`,
+  `dependency`, and `traceability`
+
+TypeScript-specific extraction facts are emitted through the
+`governance-extension:typescript` model expansion surface owned by
+`@anarchitects/governance-extension-typescript`. The adapter does not keep
+TypeScript semantics in canonical metadata as the primary contract surface.
 
 ## Usage
 
@@ -183,6 +196,17 @@ Projection precedence is deterministic:
   inferred from discovery tags.
 - Package governance metadata still wins over discovery-derived defaults for
   `domain`, `layer`, `scope`, and ownership when both are present.
+
+### Normalization Boundary
+
+The adapter owns extraction and deterministic normalization only.
+
+- Generic governance facts map into canonical Core fields.
+- TypeScript-specific facts such as `tsconfig`, import evidence, package
+  manager dependency details, and path alias resolution map into the
+  TypeScript extension expansion surface.
+- Adapter-specific extraction config remains adapter/host-owned and does not
+  expand the canonical Governance profile.
 
 ## Related Packages
 

--- a/packages/governance/adapter-typescript/package.json
+++ b/packages/governance/adapter-typescript/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@anarchitects/governance-core": "^0.3.0",
+    "@anarchitects/governance-extension-typescript": "^0.1.2",
     "minimatch": "^10.1.1",
     "typescript": "~5.9.2",
     "yaml": "^2.8.1"

--- a/packages/governance/adapter-typescript/src/extension-normalization.ts
+++ b/packages/governance/adapter-typescript/src/extension-normalization.ts
@@ -1,0 +1,174 @@
+import {
+  createTypeScriptGovernanceModelExpansion,
+  type TypeScriptGovernanceNodeExpansionData,
+  type TypeScriptGovernanceRelationExpansionData,
+  type TypeScriptGovernanceWorkspaceExpansionData,
+} from '@anarchitects/governance-extension-typescript';
+
+import type {
+  TsConfigResolutionModel,
+  TypeScriptDiscoveredProject,
+  WorkspacePackageResolution,
+} from './types.js';
+
+export function buildTypeScriptWorkspaceExpansion(
+  workspaceName: string,
+  packageJsonPath: string,
+  packageJson: Record<string, unknown> | undefined,
+  workspace: WorkspacePackageResolution,
+  tsconfig: TsConfigResolutionModel,
+  projects: readonly TypeScriptDiscoveredProject[],
+) {
+  return createTypeScriptGovernanceModelExpansion({
+    kind: 'workspace',
+    technology: 'typescript',
+    packageManager: workspace.packageManager ?? 'unknown',
+    workspacePatterns: [...workspace.patterns],
+    workspacePackageName: workspaceName,
+    packageJsonPath,
+    ...(packageJson ? { packageJson } : {}),
+    projectNodeIds: [...projects].map((project) => project.id).sort(),
+    tsconfigNodeIds: [...tsconfig.configFiles]
+      .sort((left, right) => left.localeCompare(right))
+      .map((configFile) => `tsconfig:${configFile}`),
+  } satisfies TypeScriptGovernanceWorkspaceExpansionData);
+}
+
+export function buildTypeScriptWorkspacePackageNodeExpansion(
+  packageManager: WorkspacePackageResolution['packageManager'],
+  packageJsonPath: string,
+  packageJson: Record<string, unknown> | undefined,
+  options: {
+    packageName: string;
+    workspace: boolean;
+    external?: boolean;
+  },
+) {
+  return createTypeScriptGovernanceModelExpansion({
+    kind: 'node',
+    technology: 'typescript',
+    nodeKind: 'package-manager-package',
+    packageManager: packageManager ?? 'unknown',
+    packageName: options.packageName,
+    packageJsonPath,
+    ...(packageJson ? { packageJson } : {}),
+    packageManagerPackage: {
+      workspace: options.workspace,
+      external: options.external ?? false,
+      packageName: options.packageName,
+    },
+  } satisfies TypeScriptGovernanceNodeExpansionData);
+}
+
+export function buildTypeScriptProjectNodeExpansion(
+  project: TypeScriptDiscoveredProject,
+  packageManager: WorkspacePackageResolution['packageManager'],
+  packageJsonPath: string | undefined,
+  packageJson: Record<string, unknown> | undefined,
+) {
+  return createTypeScriptGovernanceModelExpansion({
+    kind: 'node',
+    technology: 'typescript',
+    nodeKind: 'workspace-project',
+    packageManager: packageManager ?? 'unknown',
+    ...(project.name ? { packageName: project.name } : {}),
+    ...(packageJsonPath ? { packageJsonPath } : {}),
+    ...(packageJson ? { packageJson } : {}),
+    workspaceProject: {
+      id: project.id,
+      ...(project.type ? { type: project.type } : {}),
+      ...(project.root ? { projectRoot: project.root } : {}),
+    },
+  } satisfies TypeScriptGovernanceNodeExpansionData);
+}
+
+export function buildTypeScriptTsconfigNodeExpansion(
+  configFile: string,
+  tsconfig: TsConfigResolutionModel,
+) {
+  return createTypeScriptGovernanceModelExpansion({
+    kind: 'node',
+    technology: 'typescript',
+    nodeKind: 'tsconfig',
+    tsconfig: {
+      configFile,
+      ...(configFile === tsconfig.configFiles.at(-1)
+        ? {
+            ...(tsconfig.baseUrl ? { baseUrl: tsconfig.baseUrl } : {}),
+            pathAliases: tsconfig.pathAliases,
+          }
+        : {}),
+    },
+  } satisfies TypeScriptGovernanceNodeExpansionData);
+}
+
+export function buildTypeScriptWorkspaceMemberRelationExpansion(
+  projectRoot: string,
+) {
+  return createTypeScriptGovernanceModelExpansion({
+    kind: 'relation',
+    technology: 'typescript',
+    relationKind: 'workspace-member',
+    workspaceMember: {
+      projectRoot,
+    },
+  } satisfies TypeScriptGovernanceRelationExpansionData);
+}
+
+export function buildTypeScriptPackageDependencyRelationExpansion(options: {
+  packageManager: WorkspacePackageResolution['packageManager'];
+  dependencyType: string;
+  packageName: string;
+  specifier: string;
+}) {
+  return createTypeScriptGovernanceModelExpansion({
+    kind: 'relation',
+    technology: 'typescript',
+    relationKind: 'package-dependency',
+    packageDependency: {
+      packageManager: options.packageManager ?? 'unknown',
+      dependencyType: options.dependencyType,
+      packageName: options.packageName,
+      specifier: options.specifier,
+    },
+  } satisfies TypeScriptGovernanceRelationExpansionData);
+}
+
+export function buildTypeScriptPathMappingRelationExpansion(options: {
+  alias: string;
+  target: string;
+  tsconfig: string;
+}) {
+  return createTypeScriptGovernanceModelExpansion({
+    kind: 'relation',
+    technology: 'typescript',
+    relationKind: 'path-alias',
+    pathMapping: {
+      alias: options.alias,
+      target: options.target,
+      tsconfig: options.tsconfig,
+    },
+  } satisfies TypeScriptGovernanceRelationExpansionData);
+}
+
+export function buildTypeScriptImportRelationExpansion(options: {
+  sourceFile: string;
+  specifier: string;
+  importKind: string;
+  external: boolean;
+  resolvedFile?: string;
+}) {
+  return createTypeScriptGovernanceModelExpansion({
+    kind: 'relation',
+    technology: 'typescript',
+    relationKind: 'import',
+    importSpecifiers: [options.specifier],
+    import: {
+      sourceFile: options.sourceFile,
+      specifier: options.specifier,
+      importKind: options.importKind,
+      external: options.external,
+      ...(options.resolvedFile ? { resolvedFile: options.resolvedFile } : {}),
+    },
+  } satisfies TypeScriptGovernanceRelationExpansionData);
+}

--- a/packages/governance/adapter-typescript/src/map-imports-to-projects.spec.ts
+++ b/packages/governance/adapter-typescript/src/map-imports-to-projects.spec.ts
@@ -391,7 +391,7 @@ function relation(
     id: `typescript:import:${sourceNodeId}->${targetNodeId}:static-import:${specifier}`,
     sourceNodeId,
     targetNodeId,
-    kind: 'import',
+    kind: 'dependency',
     source: {
       id: 'typescript-import-graph',
       name: 'TypeScript import graph',
@@ -399,17 +399,22 @@ function relation(
     },
     authority: 'discovered',
     confidence: 1,
-    metadata: {
-      typescript: expect.objectContaining({
-        import: expect.objectContaining({
-          sourceFile,
-          specifier,
-          importKind: 'static-import',
-          external,
-          ...(resolvedFile ? { resolvedFile } : {}),
+    extensions: expect.objectContaining({
+      'governance-extension:typescript': expect.objectContaining({
+        data: expect.objectContaining({
+          kind: 'relation',
+          relationKind: 'import',
+          import: expect.objectContaining({
+            sourceFile,
+            specifier,
+            importKind: 'static-import',
+            external,
+            ...(resolvedFile ? { resolvedFile } : {}),
+          }),
         }),
       }),
-    },
+    }),
+    metadata: {},
   };
 }
 

--- a/packages/governance/adapter-typescript/src/map-imports-to-projects.ts
+++ b/packages/governance/adapter-typescript/src/map-imports-to-projects.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import type { GovernanceRelationInput } from '@anarchitects/governance-core';
 
+import { buildTypeScriptImportRelationExpansion } from './extension-normalization.js';
 import {
   ambiguousProjectMatchDiagnostic,
   resolvedImportOutsideProjectDiagnostic,
@@ -321,21 +322,22 @@ function createImportRelation(
     id: buildTypeScriptImportRelationId(sourceNodeId, targetNodeId, edge),
     sourceNodeId,
     targetNodeId,
-    kind: 'import',
+    kind: 'dependency',
     source: TYPESCRIPT_IMPORT_SOURCE,
     authority: 'discovered',
     confidence: 1,
-    metadata: {
-      typescript: {
-        import: {
+    extensions: {
+      'governance-extension:typescript': buildTypeScriptImportRelationExpansion(
+        {
           sourceFile: edge.sourceFile,
           specifier: edge.specifier,
           importKind: edge.kind,
           external: edge.external,
           ...(edge.resolvedFile ? { resolvedFile: edge.resolvedFile } : {}),
         },
-      },
+      ),
     },
+    metadata: {},
   };
 }
 
@@ -348,26 +350,22 @@ function buildTypeScriptImportRelationId(
 }
 
 function relationSourceFile(relation: GovernanceRelationInput): string {
-  const metadata = relation.metadata;
-  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
-    return '';
-  }
+  const expansion = relation.extensions?.['governance-extension:typescript'];
+  const data =
+    expansion && typeof expansion === 'object' && 'data' in expansion
+      ? (expansion.data as Record<string, unknown>)
+      : undefined;
+  const importMetadata =
+    data &&
+    typeof data === 'object' &&
+    !Array.isArray(data) &&
+    typeof data.import === 'object' &&
+    data.import !== null &&
+    !Array.isArray(data.import)
+      ? (data.import as Record<string, unknown>)
+      : undefined;
 
-  const typescript = (metadata as Record<string, unknown>).typescript;
-  if (
-    !typescript ||
-    typeof typescript !== 'object' ||
-    Array.isArray(typescript)
-  ) {
-    return '';
-  }
-
-  const importMetadata = (typescript as Record<string, unknown>).import;
-  if (
-    !importMetadata ||
-    typeof importMetadata !== 'object' ||
-    Array.isArray(importMetadata)
-  ) {
+  if (!importMetadata) {
     return '';
   }
 

--- a/packages/governance/adapter-typescript/src/tsconfig-alias-fixtures.spec.ts
+++ b/packages/governance/adapter-typescript/src/tsconfig-alias-fixtures.spec.ts
@@ -260,14 +260,17 @@ function relation(
   return expect.objectContaining({
     sourceNodeId,
     targetNodeId,
-    kind: 'import',
-    metadata: {
-      typescript: {
-        import: expect.objectContaining({
-          sourceFile,
+    kind: 'dependency',
+    extensions: expect.objectContaining({
+      'governance-extension:typescript': expect.objectContaining({
+        data: expect.objectContaining({
+          relationKind: 'import',
+          import: expect.objectContaining({
+            sourceFile,
+          }),
         }),
-      },
-    },
+      }),
+    }),
   });
 }
 

--- a/packages/governance/adapter-typescript/src/workspace-adapter.spec.ts
+++ b/packages/governance/adapter-typescript/src/workspace-adapter.spec.ts
@@ -52,31 +52,50 @@ describe('createTypeScriptWorkspaceAdapter', () => {
       expect.arrayContaining([
         expect.objectContaining({
           id: 'workspace:@fixture/root',
-          kind: 'package-manager-package',
+          kind: 'resource',
           sourceSystem: 'pnpm',
+          extensions: expect.objectContaining({
+            'governance-extension:typescript': expect.objectContaining({
+              data: expect.objectContaining({
+                kind: 'node',
+                nodeKind: 'package-manager-package',
+                packageManagerPackage: expect.objectContaining({
+                  workspace: true,
+                }),
+              }),
+            }),
+          }),
         }),
         expect.objectContaining({
           id: 'web',
           name: 'web',
           root: 'apps/web',
           path: 'apps/web',
-          kind: 'typescript-workspace-project',
+          kind: 'project',
           technology: 'typescript',
           sourceSystem: 'pnpm',
           tags: expect.arrayContaining(['type:app']),
           classification: expect.objectContaining({
             tags: expect.arrayContaining(['type:app']),
           }),
+          extensions: expect.objectContaining({
+            'governance-extension:typescript': expect.objectContaining({
+              data: expect.objectContaining({
+                kind: 'node',
+                nodeKind: 'workspace-project',
+              }),
+            }),
+          }),
         }),
         expect.objectContaining({
           id: 'customer',
           root: 'packages/customer',
-          kind: 'typescript-workspace-project',
+          kind: 'project',
         }),
         expect.objectContaining({
           id: 'order',
           root: 'packages/order',
-          kind: 'typescript-workspace-project',
+          kind: 'project',
         }),
       ]),
     );
@@ -86,25 +105,29 @@ describe('createTypeScriptWorkspaceAdapter', () => {
           id: 'typescript:workspace-member:workspace:@fixture/root->customer',
           sourceNodeId: 'workspace:@fixture/root',
           targetNodeId: 'customer',
-          kind: 'workspace-member',
+          kind: 'traceability',
         }),
         expect.objectContaining({
           sourceNodeId: 'customer',
           targetNodeId: 'order',
-          kind: 'import',
-          metadata: {
-            typescript: {
-              import: expect.objectContaining({
-                sourceFile: 'packages/customer/src/index.ts',
-                importKind: 'static-import',
+          kind: 'dependency',
+          extensions: expect.objectContaining({
+            'governance-extension:typescript': expect.objectContaining({
+              data: expect.objectContaining({
+                kind: 'relation',
+                relationKind: 'import',
+                import: expect.objectContaining({
+                  sourceFile: 'packages/customer/src/index.ts',
+                  importKind: 'static-import',
+                }),
               }),
-            },
-          },
+            }),
+          }),
         }),
         expect.objectContaining({
           sourceNodeId: 'web',
           targetNodeId: 'customer',
-          kind: 'import',
+          kind: 'dependency',
         }),
       ]),
     );
@@ -237,17 +260,20 @@ describe('generic Governance adapter exports', () => {
             ]),
           }),
           metadata: expect.objectContaining({
-            typescript: {
-              workspaceProject: expect.objectContaining({
-                type: 'frontend-app',
-                domain: 'commerce',
-                layer: 'app',
-                scope: 'web',
-              }),
-            },
             discovery: {
               runtime: 'browser',
             },
+          }),
+          extensions: expect.objectContaining({
+            'governance-extension:typescript': expect.objectContaining({
+              data: expect.objectContaining({
+                kind: 'node',
+                nodeKind: 'workspace-project',
+                workspaceProject: expect.objectContaining({
+                  type: 'frontend-app',
+                }),
+              }),
+            }),
           }),
         }),
         expect.objectContaining({
@@ -319,8 +345,16 @@ describe('generic Governance adapter exports', () => {
       expect.arrayContaining([
         expect.objectContaining({
           id: 'tsconfig:tsconfig.json',
-          kind: 'typescript-tsconfig',
+          kind: 'resource',
           technology: 'typescript',
+          extensions: expect.objectContaining({
+            'governance-extension:typescript': expect.objectContaining({
+              data: expect.objectContaining({
+                kind: 'node',
+                nodeKind: 'tsconfig',
+              }),
+            }),
+          }),
         }),
       ]),
     );
@@ -329,12 +363,12 @@ describe('generic Governance adapter exports', () => {
         expect.objectContaining({
           sourceNodeId: 'tsconfig:tsconfig.json',
           targetNodeId: 'customer',
-          kind: 'path-mapping',
+          kind: 'traceability',
         }),
         expect.objectContaining({
           sourceNodeId: 'tsconfig:tsconfig.json',
           targetNodeId: 'order',
-          kind: 'path-mapping',
+          kind: 'traceability',
         }),
       ]),
     );

--- a/packages/governance/adapter-typescript/src/workspace-adapter.ts
+++ b/packages/governance/adapter-typescript/src/workspace-adapter.ts
@@ -15,6 +15,15 @@ import type {
 } from '@anarchitects/governance-core';
 
 import { detectTypeScriptWorkspace } from './detect-typescript-workspace.js';
+import {
+  buildTypeScriptPackageDependencyRelationExpansion,
+  buildTypeScriptPathMappingRelationExpansion,
+  buildTypeScriptProjectNodeExpansion,
+  buildTypeScriptTsconfigNodeExpansion,
+  buildTypeScriptWorkspaceExpansion,
+  buildTypeScriptWorkspaceMemberRelationExpansion,
+  buildTypeScriptWorkspacePackageNodeExpansion,
+} from './extension-normalization.js';
 import { buildTypeScriptImportGraph } from './import-graph.js';
 import { loadPackageMetadata } from './load-package-metadata.js';
 import { mapTypeScriptImportsToGovernanceDependencies } from './map-imports-to-projects.js';
@@ -128,10 +137,12 @@ export function createTypeScriptWorkspaceAdapter(
       });
 
       const workspaceName = inferWorkspaceName(workspaceRoot);
+      const workspacePackageMetadata = loadPackageMetadata(workspaceRoot);
       const workspaceNode = buildWorkspaceNode(
         workspaceRoot,
         workspaceName,
         workspace.packageManager,
+        workspacePackageMetadata,
       );
       const projectPackageMetadata = readProjectPackageMetadata(
         workspaceRoot,
@@ -183,14 +194,18 @@ export function createTypeScriptWorkspaceAdapter(
           ...importGraph.diagnostics,
           ...mapping.diagnostics,
         ]),
-        metadata: {
-          packageManager: workspace.packageManager ?? 'unknown',
-          workspacePatterns: [...workspace.patterns],
-          tsconfig: {
-            configFiles: [...tsconfig.configFiles],
-            ...(tsconfig.baseUrl ? { baseUrl: tsconfig.baseUrl } : {}),
-            pathAliasCount: Object.keys(tsconfig.pathAliases).length,
-          },
+        extensions: {
+          'governance-extension:typescript': buildTypeScriptWorkspaceExpansion(
+            workspaceName,
+            normalizeRelativePath(
+              workspaceRoot,
+              workspacePackageMetadata.packageJsonPath,
+            ),
+            workspacePackageMetadata.packageJson,
+            workspace,
+            tsconfig,
+            discovered.projects,
+          ),
         },
       };
     },
@@ -219,32 +234,35 @@ function buildWorkspaceNode(
   workspaceRoot: string,
   workspaceName: string,
   packageManager?: WorkspacePackageResolution['packageManager'],
+  metadata?: LoadedPackageMetadata,
 ): GovernanceNodeInput {
-  const metadata = loadPackageMetadata(workspaceRoot);
+  const packageMetadata = metadata ?? loadPackageMetadata(workspaceRoot);
   const packageName =
-    readOptionalString(metadata.packageJson?.name) ?? workspaceName;
+    readOptionalString(packageMetadata.packageJson?.name) ?? workspaceName;
 
   return {
     id: buildWorkspaceNodeId(packageName),
     name: packageName,
-    kind: 'package-manager-package',
+    kind: 'resource',
     sourceSystem: packageManager ?? 'npm',
     root: '.',
     path: 'package.json',
     source: TYPESCRIPT_ADAPTER_SOURCE,
     authority: 'documented',
     confidence: 1,
-    metadata: {
-      packageManager: {
-        workspace: true,
-        packageManager: packageManager ?? 'unknown',
-        packageJsonPath: normalizeRelativePath(
-          workspaceRoot,
-          metadata.packageJsonPath,
+    extensions: {
+      'governance-extension:typescript':
+        buildTypeScriptWorkspacePackageNodeExpansion(
+          packageManager,
+          normalizeRelativePath(workspaceRoot, packageMetadata.packageJsonPath),
+          packageMetadata.packageJson,
+          {
+            packageName,
+            workspace: true,
+          },
         ),
-        ...(metadata.packageJson ? { packageJson: metadata.packageJson } : {}),
-      },
     },
+    metadata: {},
   };
 }
 
@@ -259,7 +277,7 @@ function buildProjectNode(
   return {
     id: project.id,
     name: project.name ?? project.id,
-    kind: project.kind ?? 'typescript-workspace-project',
+    kind: project.kind ?? 'project',
     technology: 'typescript',
     sourceSystem: packageManager ?? 'typescript',
     ...(root ? { root } : {}),
@@ -272,27 +290,15 @@ function buildProjectNode(
     source: TYPESCRIPT_ADAPTER_SOURCE,
     authority: 'discovered',
     confidence: 1,
+    extensions: {
+      'governance-extension:typescript': buildTypeScriptProjectNodeExpansion(
+        project,
+        packageManager,
+        packageMetadata?.packageJsonPath,
+        packageMetadata?.packageJson,
+      ),
+    },
     metadata: {
-      typescript: {
-        workspaceProject: {
-          id: project.id,
-          ...(project.type ? { type: project.type } : {}),
-          ...(project.domain ? { domain: project.domain } : {}),
-          ...(project.layer ? { layer: project.layer } : {}),
-          ...(project.scope ? { scope: project.scope } : {}),
-        },
-      },
-      ...(packageMetadata
-        ? {
-            packageManager: {
-              packageManager: packageManager ?? 'unknown',
-              packageJsonPath: packageMetadata.packageJsonPath,
-              ...(packageMetadata.packageJson
-                ? { packageJson: packageMetadata.packageJson }
-                : {}),
-            },
-          }
-        : {}),
       ...(project.metadata ? { discovery: project.metadata } : {}),
     },
   };
@@ -326,7 +332,7 @@ function buildTsconfigNodes(
     .map((configFile) => ({
       id: buildTsconfigNodeId(configFile),
       name: path.basename(configFile),
-      kind: 'typescript-tsconfig',
+      kind: 'resource',
       technology: 'typescript',
       sourceSystem: 'typescript',
       root: path.posix.dirname(configFile),
@@ -334,19 +340,13 @@ function buildTsconfigNodes(
       source: TYPESCRIPT_ADAPTER_SOURCE,
       authority: 'documented',
       confidence: 1,
-      metadata: {
-        typescript: {
-          tsconfig: {
-            configFile,
-            ...(configFile === tsconfig.configFiles.at(-1)
-              ? {
-                  ...(tsconfig.baseUrl ? { baseUrl: tsconfig.baseUrl } : {}),
-                  pathAliases: tsconfig.pathAliases,
-                }
-              : {}),
-          },
-        },
+      extensions: {
+        'governance-extension:typescript': buildTypeScriptTsconfigNodeExpansion(
+          configFile,
+          tsconfig,
+        ),
       },
+      metadata: {},
     }));
 }
 
@@ -384,18 +384,25 @@ function buildExternalPackageNodes(
       nodes.set(id, {
         id,
         name: dependency.name,
-        kind: 'package-manager-package',
+        kind: 'resource',
         sourceSystem: packageManager ?? 'npm',
         source: TYPESCRIPT_ADAPTER_SOURCE,
         authority: 'documented',
         confidence: 1,
-        metadata: {
-          packageManager: {
-            packageManager: packageManager ?? 'unknown',
-            external: true,
-            packageName: dependency.name,
-          },
+        extensions: {
+          'governance-extension:typescript':
+            buildTypeScriptWorkspacePackageNodeExpansion(
+              packageManager,
+              '',
+              undefined,
+              {
+                packageName: dependency.name,
+                workspace: false,
+                external: true,
+              },
+            ),
         },
+        metadata: {},
       });
     }
   }
@@ -415,17 +422,15 @@ function buildWorkspaceMembershipRelations(
       id: `typescript:workspace-member:${workspaceNodeId}->${project.id}`,
       sourceNodeId: workspaceNodeId,
       targetNodeId: project.id,
-      kind: 'workspace-member',
+      kind: 'traceability',
       source: TYPESCRIPT_ADAPTER_SOURCE,
       authority: 'documented',
       confidence: 1,
-      metadata: {
-        typescript: {
-          workspaceMember: {
-            projectRoot: project.root ?? '',
-          },
-        },
+      extensions: {
+        'governance-extension:typescript':
+          buildTypeScriptWorkspaceMemberRelationExpansion(project.root ?? ''),
       },
+      metadata: {},
     }));
 }
 
@@ -475,14 +480,16 @@ function buildPackageDependencyRelations(
         source: TYPESCRIPT_ADAPTER_SOURCE,
         authority: 'documented',
         confidence: 1,
-        metadata: {
-          packageManager: {
-            packageManager: packageManager ?? 'unknown',
-            dependencyType: dependency.type,
-            packageName: dependency.name,
-            specifier: dependency.specifier,
-          },
+        extensions: {
+          'governance-extension:typescript':
+            buildTypeScriptPackageDependencyRelationExpansion({
+              packageManager,
+              dependencyType: dependency.type,
+              packageName: dependency.name,
+              specifier: dependency.specifier,
+            }),
         },
+        metadata: {},
       });
     }
   }
@@ -523,19 +530,19 @@ function buildTsconfigPathMappingRelations(
             id: relationId,
             sourceNodeId: tsconfigNodeId,
             targetNodeId: project.id,
-            kind: 'path-mapping',
+            kind: 'traceability',
             source: TYPESCRIPT_ADAPTER_SOURCE,
             authority: 'documented',
             confidence: 1,
-            metadata: {
-              typescript: {
-                pathMapping: {
+            extensions: {
+              'governance-extension:typescript':
+                buildTypeScriptPathMappingRelationExpansion({
                   alias,
                   target,
                   tsconfig: configFile,
-                },
-              },
+                }),
             },
+            metadata: {},
           });
         }
       }

--- a/packages/governance/adapter-typescript/src/workspace-behavior-fixtures.spec.ts
+++ b/packages/governance/adapter-typescript/src/workspace-behavior-fixtures.spec.ts
@@ -278,14 +278,17 @@ function relation(
   return expect.objectContaining({
     sourceNodeId,
     targetNodeId,
-    kind: 'import',
-    metadata: {
-      typescript: {
-        import: expect.objectContaining({
-          sourceFile,
+    kind: 'dependency',
+    extensions: expect.objectContaining({
+      'governance-extension:typescript': expect.objectContaining({
+        data: expect.objectContaining({
+          relationKind: 'import',
+          import: expect.objectContaining({
+            sourceFile,
+          }),
         }),
-      },
-    },
+      }),
+    }),
   });
 }
 

--- a/packages/governance/adapter-typescript/tsconfig.lib.json
+++ b/packages/governance/adapter-typescript/tsconfig.lib.json
@@ -14,6 +14,9 @@
   "references": [
     {
       "path": "../core/tsconfig.lib.json"
+    },
+    {
+      "path": "../extension-typescript/tsconfig.lib.json"
     }
   ],
   "exclude": [

--- a/packages/governance/extension-typescript/src/contracts.ts
+++ b/packages/governance/extension-typescript/src/contracts.ts
@@ -44,6 +44,10 @@ export interface TypeScriptGovernanceWorkspaceExpansionData {
   kind: 'workspace';
   technology: 'typescript';
   packageManager?: string;
+  workspacePatterns?: string[];
+  workspacePackageName?: string;
+  packageJsonPath?: string;
+  packageJson?: Record<string, unknown>;
   projectNodeIds?: string[];
   tsconfigNodeIds?: string[];
 }
@@ -56,8 +60,25 @@ export interface TypeScriptGovernanceNodeExpansionData {
     | 'tsconfig'
     | 'package-manager-package'
     | 'unknown';
+  packageManager?: string;
   packageName?: string;
-  tsconfigPath?: string;
+  packageJsonPath?: string;
+  packageJson?: Record<string, unknown>;
+  workspaceProject?: {
+    id: string;
+    type?: string;
+    projectRoot?: string;
+  };
+  tsconfig?: {
+    configFile: string;
+    baseUrl?: string;
+    pathAliases?: Record<string, string[]>;
+  };
+  packageManagerPackage?: {
+    external?: boolean;
+    workspace?: boolean;
+    packageName?: string;
+  };
 }
 
 export interface TypeScriptGovernanceRelationExpansionData {
@@ -66,10 +87,32 @@ export interface TypeScriptGovernanceRelationExpansionData {
   relationKind:
     | 'import'
     | 'path-alias'
+    | 'workspace-member'
     | 'tsconfig-extends'
     | 'package-dependency'
     | 'unknown';
   importSpecifiers?: string[];
+  import?: {
+    sourceFile?: string;
+    specifier?: string;
+    importKind?: string;
+    external?: boolean;
+    resolvedFile?: string;
+  };
+  pathMapping?: {
+    alias: string;
+    target: string;
+    tsconfig: string;
+  };
+  workspaceMember?: {
+    projectRoot: string;
+  };
+  packageDependency?: {
+    packageManager?: string;
+    dependencyType?: string;
+    packageName?: string;
+    specifier?: string;
+  };
 }
 
 export interface TypeScriptGovernanceRuntimeContextExpansionData {
@@ -300,6 +343,15 @@ export function validateTypeScriptGovernanceModelExpansion(
 
   switch (data.kind) {
     case 'workspace':
+      if (data.packageJson !== undefined && !isRecord(data.packageJson)) {
+        issues.push({
+          code: 'typescript.expansion.invalid_workspace_package_json',
+          severity: 'error',
+          message:
+            'TypeScript workspace expansion packageJson must be an object when present.',
+          path: '/data/packageJson',
+        });
+      }
       validateOptionalStringArray(
         data.projectNodeIds,
         '/data/projectNodeIds',
@@ -310,6 +362,11 @@ export function validateTypeScriptGovernanceModelExpansion(
         '/data/tsconfigNodeIds',
         issues,
       );
+      validateOptionalStringArray(
+        data.workspacePatterns,
+        '/data/workspacePatterns',
+        issues,
+      );
       break;
     case 'node':
       validateEnum(
@@ -318,6 +375,48 @@ export function validateTypeScriptGovernanceModelExpansion(
         '/data/nodeKind',
         issues,
       );
+      if (data.packageJson !== undefined && !isRecord(data.packageJson)) {
+        issues.push({
+          code: 'typescript.expansion.invalid_node_package_json',
+          severity: 'error',
+          message:
+            'TypeScript node expansion packageJson must be an object when present.',
+          path: '/data/packageJson',
+        });
+      }
+      if (
+        data.workspaceProject !== undefined &&
+        !isRecord(data.workspaceProject)
+      ) {
+        issues.push({
+          code: 'typescript.expansion.invalid_workspace_project',
+          severity: 'error',
+          message:
+            'TypeScript node expansion workspaceProject must be an object when present.',
+          path: '/data/workspaceProject',
+        });
+      }
+      if (data.tsconfig !== undefined && !isRecord(data.tsconfig)) {
+        issues.push({
+          code: 'typescript.expansion.invalid_tsconfig',
+          severity: 'error',
+          message:
+            'TypeScript node expansion tsconfig must be an object when present.',
+          path: '/data/tsconfig',
+        });
+      }
+      if (
+        data.packageManagerPackage !== undefined &&
+        !isRecord(data.packageManagerPackage)
+      ) {
+        issues.push({
+          code: 'typescript.expansion.invalid_package_manager_package',
+          severity: 'error',
+          message:
+            'TypeScript node expansion packageManagerPackage must be an object when present.',
+          path: '/data/packageManagerPackage',
+        });
+      }
       break;
     case 'relation':
       validateEnum(
@@ -325,6 +424,7 @@ export function validateTypeScriptGovernanceModelExpansion(
         [
           'import',
           'path-alias',
+          'workspace-member',
           'tsconfig-extends',
           'package-dependency',
           'unknown',
@@ -337,6 +437,48 @@ export function validateTypeScriptGovernanceModelExpansion(
         '/data/importSpecifiers',
         issues,
       );
+      if (data.import !== undefined && !isRecord(data.import)) {
+        issues.push({
+          code: 'typescript.expansion.invalid_import',
+          severity: 'error',
+          message:
+            'TypeScript relation expansion import must be an object when present.',
+          path: '/data/import',
+        });
+      }
+      if (data.pathMapping !== undefined && !isRecord(data.pathMapping)) {
+        issues.push({
+          code: 'typescript.expansion.invalid_path_mapping',
+          severity: 'error',
+          message:
+            'TypeScript relation expansion pathMapping must be an object when present.',
+          path: '/data/pathMapping',
+        });
+      }
+      if (
+        data.workspaceMember !== undefined &&
+        !isRecord(data.workspaceMember)
+      ) {
+        issues.push({
+          code: 'typescript.expansion.invalid_workspace_member',
+          severity: 'error',
+          message:
+            'TypeScript relation expansion workspaceMember must be an object when present.',
+          path: '/data/workspaceMember',
+        });
+      }
+      if (
+        data.packageDependency !== undefined &&
+        !isRecord(data.packageDependency)
+      ) {
+        issues.push({
+          code: 'typescript.expansion.invalid_package_dependency',
+          severity: 'error',
+          message:
+            'TypeScript relation expansion packageDependency must be an object when present.',
+          path: '/data/packageDependency',
+        });
+      }
       break;
     case 'runtime-context':
       if (data.config !== undefined && !isRecord(data.config)) {

--- a/packages/governance/extension-typescript/src/diagnostics.ts
+++ b/packages/governance/extension-typescript/src/diagnostics.ts
@@ -10,6 +10,8 @@ import type {
   TypeScriptGovernanceDiagnosticProviderInput,
 } from './contracts.js';
 import {
+  getPackageManagerMetadata,
+  getTypeScriptMetadata,
   getImportRelations,
   getPathMappingRelations,
   getTsconfigNodes,
@@ -48,7 +50,7 @@ export interface TypeScriptGovernanceExtensionDiagnostic
   details?: TypeScriptGovernanceDiagnosticDetails;
 }
 
-export type TypeScriptGovernanceDiagnosticsProviderOptions = object
+export type TypeScriptGovernanceDiagnosticsProviderOptions = object;
 
 interface CreateDiagnosticOptions {
   code: TypeScriptGovernanceDiagnosticCode;
@@ -79,8 +81,7 @@ export function buildTypeScriptGovernanceDiagnostics(
   const diagnostics: TypeScriptGovernanceExtensionDiagnostic[] = [];
 
   for (const node of getTypeScriptProjectNodes(input.workspace)) {
-    const packageJson = readRecordMetadata(node.metadata, [
-      'packageManager',
+    const packageJson = readRecordMetadata(getPackageManagerMetadata(node), [
       'packageJson',
     ]);
 
@@ -91,9 +92,9 @@ export function buildTypeScriptGovernanceDiagnostics(
     diagnostics.push(
       createDiagnostic({
         code: 'TYPESCRIPT_PROJECT_PACKAGE_METADATA_MISSING',
-        message: `TypeScript node "${node.id}" is missing package-manager package metadata.`,
+        message: `TypeScript node "${node.id}" is missing TypeScript package facts.`,
         recommendation:
-          'Attach metadata.packageManager.packageJson when emitting workspace project nodes.',
+          'Populate the TypeScript extension expansion with packageJson when emitting workspace project nodes.',
         severity: 'warning',
         kind: 'observation',
         category: 'configuration',
@@ -106,8 +107,7 @@ export function buildTypeScriptGovernanceDiagnostics(
   }
 
   for (const relation of getImportRelations(input.workspace)) {
-    const importMetadata = readRecordMetadata(relation.metadata, [
-      'typescript',
+    const importMetadata = readRecordMetadata(getTypeScriptMetadata(relation), [
       'import',
     ]);
     const missingFields: string[] = [];
@@ -126,9 +126,9 @@ export function buildTypeScriptGovernanceDiagnostics(
     diagnostics.push(
       createDiagnostic({
         code: 'TYPESCRIPT_IMPORT_METADATA_INCOMPLETE',
-        message: `TypeScript relation "${relation.id}" is missing canonical import metadata: ${missingFields.join(', ')}.`,
+        message: `TypeScript relation "${relation.id}" is missing TypeScript import facts: ${missingFields.join(', ')}.`,
         recommendation:
-          'Populate metadata.typescript.import.sourceFile and metadata.typescript.import.specifier for import relations.',
+          'Populate the TypeScript extension expansion import.sourceFile and import.specifier for import relations.',
         severity: 'warning',
         kind: 'observation',
         category: 'configuration',
@@ -143,8 +143,7 @@ export function buildTypeScriptGovernanceDiagnostics(
 
   const aliasesByTsconfigId = new Map<string, Set<string>>();
   for (const relation of getPathMappingRelations(input.workspace)) {
-    const alias = readStringMetadata(relation.metadata, [
-      'typescript',
+    const alias = readStringMetadata(getTypeScriptMetadata(relation), [
       'pathMapping',
       'alias',
     ]);
@@ -158,8 +157,7 @@ export function buildTypeScriptGovernanceDiagnostics(
   }
 
   for (const node of getTsconfigNodes(input.workspace)) {
-    const aliases = readRecordMetadata(node.metadata, [
-      'typescript',
+    const aliases = readRecordMetadata(getTypeScriptMetadata(node), [
       'tsconfig',
       'pathAliases',
     ]);

--- a/packages/governance/extension-typescript/src/graph.ts
+++ b/packages/governance/extension-typescript/src/graph.ts
@@ -1,16 +1,23 @@
 import type {
   GovernanceCapability,
+  GovernanceExtensionModelExpansionCarrier,
   GovernanceNode,
   GovernanceRelation,
   GovernanceRuntimeReference,
   GovernanceWorkspace,
 } from '@anarchitects/governance-core';
 
+import type {
+  TypeScriptGovernanceModelExpansionData,
+  TypeScriptGovernanceNodeExpansionData,
+  TypeScriptGovernanceRelationExpansionData,
+} from './contracts.js';
+import { getTypeScriptGovernanceModelExpansion } from './contracts.js';
+
 const TYPESCRIPT_RELATION_KINDS = new Set([
   'dependency',
   'import',
-  'path-mapping',
-  'workspace-member',
+  'traceability',
 ]);
 
 export function getTypeScriptNodes(
@@ -35,7 +42,9 @@ export function getTypeScriptProjectNodes(
   workspace: GovernanceWorkspace,
 ): GovernanceNode[] {
   return getTypeScriptNodes(workspace).filter(
-    (node) => node.kind === 'typescript-workspace-project',
+    (node) =>
+      getTypeScriptNodeExpansionData(node)?.nodeKind === 'workspace-project' ||
+      node.kind === 'typescript-workspace-project',
   );
 }
 
@@ -43,7 +52,9 @@ export function getTsconfigNodes(
   workspace: GovernanceWorkspace,
 ): GovernanceNode[] {
   return getTypeScriptNodes(workspace).filter(
-    (node) => node.kind === 'typescript-tsconfig',
+    (node) =>
+      getTypeScriptNodeExpansionData(node)?.nodeKind === 'tsconfig' ||
+      node.kind === 'typescript-tsconfig',
   );
 }
 
@@ -51,7 +62,9 @@ export function getImportRelations(
   workspace: GovernanceWorkspace,
 ): GovernanceRelation[] {
   return getTypeScriptRelations(workspace).filter(
-    (relation) => relation.kind === 'import',
+    (relation) =>
+      getTypeScriptRelationExpansionData(relation)?.relationKind === 'import' ||
+      relation.kind === 'import',
   );
 }
 
@@ -59,7 +72,11 @@ export function getDependencyRelations(
   workspace: GovernanceWorkspace,
 ): GovernanceRelation[] {
   return getTypeScriptRelations(workspace).filter(
-    (relation) => relation.kind === 'dependency',
+    (relation) =>
+      getTypeScriptRelationExpansionData(relation)?.relationKind ===
+        'package-dependency' ||
+      (relation.kind === 'dependency' &&
+        hasPackageManagerMetadata(relation.metadata)),
   );
 }
 
@@ -67,12 +84,17 @@ export function getPathMappingRelations(
   workspace: GovernanceWorkspace,
 ): GovernanceRelation[] {
   return getTypeScriptRelations(workspace).filter(
-    (relation) => relation.kind === 'path-mapping',
+    (relation) =>
+      getTypeScriptRelationExpansionData(relation)?.relationKind ===
+        'path-alias' || relation.kind === 'path-mapping',
   );
 }
 
 export function isTypeScriptNode(node: GovernanceNode): boolean {
+  const expansion = getTypeScriptNodeExpansionData(node);
+
   return (
+    expansion?.technology === 'typescript' ||
     node.technology === 'typescript' ||
     hasTypeScriptMetadata(node.metadata) ||
     hasPackageManagerMetadata(node.metadata) ||
@@ -86,6 +108,11 @@ export function isTypeScriptRelation(
   relation: GovernanceRelation,
   nodeById: ReadonlyMap<string, GovernanceNode>,
 ): boolean {
+  const expansion = getTypeScriptRelationExpansionData(relation);
+  if (expansion?.technology === 'typescript') {
+    return true;
+  }
+
   if (
     hasTypeScriptMetadata(relation.metadata) ||
     hasPackageManagerMetadata(relation.metadata)
@@ -109,14 +136,64 @@ export function isTypeScriptRelation(
 }
 
 export function getTypeScriptMetadata(
-  subject: { metadata?: Record<string, unknown> } | undefined,
+  subject:
+    | {
+        metadata?: Record<string, unknown>;
+        extensions?: Record<string, unknown>;
+      }
+    | undefined,
 ): Record<string, unknown> | undefined {
+  const expansion = getTypeScriptExpansionData(
+    subject as GovernanceExtensionModelExpansionCarrier | undefined,
+  );
+
+  if (expansion?.kind === 'node') {
+    return buildNodeTypeScriptMetadata(expansion);
+  }
+
+  if (expansion?.kind === 'relation') {
+    return buildRelationTypeScriptMetadata(expansion);
+  }
+
   return asRecord(subject?.metadata?.typescript);
 }
 
 export function getPackageManagerMetadata(
-  subject: { metadata?: Record<string, unknown> } | undefined,
+  subject:
+    | {
+        metadata?: Record<string, unknown>;
+        extensions?: Record<string, unknown>;
+      }
+    | undefined,
 ): Record<string, unknown> | undefined {
+  const expansion = getTypeScriptExpansionData(
+    subject as GovernanceExtensionModelExpansionCarrier | undefined,
+  );
+
+  if (expansion?.kind === 'workspace') {
+    return {
+      ...(expansion.packageManager
+        ? { packageManager: expansion.packageManager }
+        : {}),
+      ...(expansion.workspacePackageName
+        ? { packageName: expansion.workspacePackageName }
+        : {}),
+      ...(expansion.packageJsonPath
+        ? { packageJsonPath: expansion.packageJsonPath }
+        : {}),
+      ...(expansion.packageJson ? { packageJson: expansion.packageJson } : {}),
+      workspace: true,
+    };
+  }
+
+  if (expansion?.kind === 'node') {
+    return buildNodePackageManagerMetadata(expansion);
+  }
+
+  if (expansion?.kind === 'relation') {
+    return buildRelationPackageManagerMetadata(expansion);
+  }
+
   return asRecord(subject?.metadata?.packageManager);
 }
 
@@ -233,4 +310,137 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
   return typeof value === 'object' && value !== null
     ? (value as Record<string, unknown>)
     : undefined;
+}
+
+function getTypeScriptExpansionData(
+  subject: GovernanceExtensionModelExpansionCarrier | undefined,
+): TypeScriptGovernanceModelExpansionData | undefined {
+  return getTypeScriptGovernanceModelExpansion(subject)?.data;
+}
+
+function getTypeScriptNodeExpansionData(
+  subject: GovernanceExtensionModelExpansionCarrier | undefined,
+): TypeScriptGovernanceNodeExpansionData | undefined {
+  const expansion = getTypeScriptExpansionData(subject);
+  return expansion?.kind === 'node' ? expansion : undefined;
+}
+
+function getTypeScriptRelationExpansionData(
+  subject: GovernanceExtensionModelExpansionCarrier | undefined,
+): TypeScriptGovernanceRelationExpansionData | undefined {
+  const expansion = getTypeScriptExpansionData(subject);
+  return expansion?.kind === 'relation' ? expansion : undefined;
+}
+
+function buildNodeTypeScriptMetadata(
+  expansion: TypeScriptGovernanceNodeExpansionData,
+): Record<string, unknown> | undefined {
+  if (expansion.nodeKind === 'workspace-project') {
+    return {
+      workspaceProject: {
+        ...(expansion.workspaceProject?.id
+          ? { id: expansion.workspaceProject.id }
+          : {}),
+        ...(expansion.workspaceProject?.type
+          ? { type: expansion.workspaceProject.type }
+          : {}),
+        ...(expansion.workspaceProject?.projectRoot
+          ? { projectRoot: expansion.workspaceProject.projectRoot }
+          : {}),
+      },
+    };
+  }
+
+  if (expansion.nodeKind === 'tsconfig' && expansion.tsconfig) {
+    return {
+      tsconfig: {
+        ...expansion.tsconfig,
+      },
+    };
+  }
+
+  return undefined;
+}
+
+function buildRelationTypeScriptMetadata(
+  expansion: TypeScriptGovernanceRelationExpansionData,
+): Record<string, unknown> | undefined {
+  if (expansion.relationKind === 'import' && expansion.import) {
+    return {
+      import: {
+        ...expansion.import,
+      },
+    };
+  }
+
+  if (expansion.relationKind === 'path-alias' && expansion.pathMapping) {
+    return {
+      pathMapping: {
+        ...expansion.pathMapping,
+      },
+    };
+  }
+
+  if (
+    expansion.relationKind === 'workspace-member' &&
+    expansion.workspaceMember
+  ) {
+    return {
+      workspaceMember: {
+        ...expansion.workspaceMember,
+      },
+    };
+  }
+
+  return undefined;
+}
+
+function buildNodePackageManagerMetadata(
+  expansion: TypeScriptGovernanceNodeExpansionData,
+): Record<string, unknown> | undefined {
+  const hasPackageManagerData =
+    expansion.packageManager !== undefined ||
+    expansion.packageName !== undefined ||
+    expansion.packageJsonPath !== undefined ||
+    expansion.packageJson !== undefined ||
+    expansion.packageManagerPackage !== undefined;
+
+  if (!hasPackageManagerData) {
+    return undefined;
+  }
+
+  return {
+    ...(expansion.packageManager
+      ? { packageManager: expansion.packageManager }
+      : {}),
+    ...(expansion.packageName ? { packageName: expansion.packageName } : {}),
+    ...(expansion.packageJsonPath
+      ? { packageJsonPath: expansion.packageJsonPath }
+      : {}),
+    ...(expansion.packageJson ? { packageJson: expansion.packageJson } : {}),
+    ...(expansion.packageManagerPackage ?? {}),
+  };
+}
+
+function buildRelationPackageManagerMetadata(
+  expansion: TypeScriptGovernanceRelationExpansionData,
+): Record<string, unknown> | undefined {
+  if (!expansion.packageDependency) {
+    return undefined;
+  }
+
+  return {
+    ...(expansion.packageDependency.packageManager
+      ? { packageManager: expansion.packageDependency.packageManager }
+      : {}),
+    ...(expansion.packageDependency.dependencyType
+      ? { dependencyType: expansion.packageDependency.dependencyType }
+      : {}),
+    ...(expansion.packageDependency.packageName
+      ? { packageName: expansion.packageDependency.packageName }
+      : {}),
+    ...(expansion.packageDependency.specifier
+      ? { specifier: expansion.packageDependency.specifier }
+      : {}),
+  };
 }

--- a/packages/governance/extension-typescript/src/metrics.ts
+++ b/packages/governance/extension-typescript/src/metrics.ts
@@ -8,6 +8,7 @@ import {
   findNodeById,
   getDependencyRelations,
   getImportRelations,
+  getPackageManagerMetadata,
   getPathMappingRelations,
   getTsconfigNodes,
   getTypeScriptProjectNodes,
@@ -68,8 +69,10 @@ export function buildTypeScriptGovernanceMetrics(
   const externalDependencyRelations = getDependencyRelations(input.workspace)
     .filter((relation) =>
       readBooleanMetadata(
-        findNodeById(input.workspace, relation.targetNodeId)?.metadata,
-        ['packageManager', 'external'],
+        getPackageManagerMetadata(
+          findNodeById(input.workspace, relation.targetNodeId),
+        ),
+        ['external'],
       ),
     )
     .sort((left, right) => left.id.localeCompare(right.id));

--- a/packages/governance/extension-typescript/src/recommendations.ts
+++ b/packages/governance/extension-typescript/src/recommendations.ts
@@ -13,6 +13,7 @@ import type {
 } from './contracts.js';
 import {
   getDependencyRelations,
+  getPackageManagerMetadata,
   readStringMetadata,
   toNodeReference,
   toRelationReference,
@@ -90,9 +91,9 @@ export function buildTypeScriptGovernanceRecommendations(
         title: 'Add package metadata to TypeScript node',
         priority: 'medium',
         reason:
-          'The TypeScript workspace project is missing canonical package-manager metadata.',
+          'The TypeScript workspace project is missing TypeScript package facts.',
         description:
-          'Populate metadata.packageManager.packageJson on the affected node so extension analysis can rely on canonical package facts.',
+          'Populate the TypeScript extension expansion packageJson on the affected node so extension analysis can rely on package facts.',
         category: 'configuration',
         reference: toNodeReference(diagnostic.reference.nodeId),
         signalIds: [],
@@ -155,8 +156,7 @@ export function buildTypeScriptGovernanceRecommendations(
         reason:
           'A TypeScript workspace dependency points to an external package rather than another governed node.',
         description: `Review dependency usage for "${
-          readStringMetadata(relation.metadata, [
-            'packageManager',
+          readStringMetadata(getPackageManagerMetadata(relation), [
             'packageName',
           ]) ?? relation.targetNodeId
         }" and decide whether it should remain external or become governed workspace scope.`,

--- a/packages/governance/extension-typescript/src/signals.ts
+++ b/packages/governance/extension-typescript/src/signals.ts
@@ -15,7 +15,9 @@ import {
   findNodeById,
   getDependencyRelations,
   getImportRelations,
+  getPackageManagerMetadata,
   getPathMappingRelations,
+  getTypeScriptMetadata,
   getTypeScriptProjectNodes,
   normalizeIds,
   readBooleanMetadata,
@@ -122,18 +124,15 @@ export function buildTypeScriptGovernanceSignals(
       ]),
       relatedRelationIds: [relation.id],
       metadata: {
-        sourceFile: readStringMetadata(relation.metadata, [
-          'typescript',
+        sourceFile: readStringMetadata(getTypeScriptMetadata(relation), [
           'import',
           'sourceFile',
         ]),
-        specifier: readStringMetadata(relation.metadata, [
-          'typescript',
+        specifier: readStringMetadata(getTypeScriptMetadata(relation), [
           'import',
           'specifier',
         ]),
-        importKind: readStringMetadata(relation.metadata, [
-          'typescript',
+        importKind: readStringMetadata(getTypeScriptMetadata(relation), [
           'import',
           'importKind',
         ]),
@@ -157,8 +156,7 @@ export function buildTypeScriptGovernanceSignals(
       ]),
       relatedRelationIds: [relation.id],
       metadata: {
-        alias: readStringMetadata(relation.metadata, [
-          'typescript',
+        alias: readStringMetadata(getTypeScriptMetadata(relation), [
           'pathMapping',
           'alias',
         ]),
@@ -170,7 +168,7 @@ export function buildTypeScriptGovernanceSignals(
   for (const relation of getDependencyRelations(input.workspace)) {
     const targetNode = findNodeById(input.workspace, relation.targetNodeId);
     if (
-      !readBooleanMetadata(targetNode?.metadata, ['packageManager', 'external'])
+      !readBooleanMetadata(getPackageManagerMetadata(targetNode), ['external'])
     ) {
       continue;
     }
@@ -189,13 +187,12 @@ export function buildTypeScriptGovernanceSignals(
       ]),
       relatedRelationIds: [relation.id],
       metadata: {
-        dependencyType: readStringMetadata(relation.metadata, [
-          'packageManager',
-          'dependencyType',
-        ]),
+        dependencyType: readStringMetadata(
+          getPackageManagerMetadata(relation),
+          ['dependencyType'],
+        ),
         packageName:
-          readStringMetadata(relation.metadata, [
-            'packageManager',
+          readStringMetadata(getPackageManagerMetadata(relation), [
             'packageName',
           ]) ?? targetNode?.name,
       },

--- a/packages/governance/extension-typescript/src/test-workspace.ts
+++ b/packages/governance/extension-typescript/src/test-workspace.ts
@@ -8,6 +8,8 @@ import {
   type GovernanceWorkspace,
 } from '@anarchitects/governance-core';
 
+import { attachTypeScriptGovernanceModelExpansion } from './contracts.js';
+
 export function createTypeScriptProfile(
   overrides: Partial<GovernanceProfile> = {},
 ): GovernanceProfile {
@@ -72,10 +74,10 @@ export function createTypeScriptProjectNode(options: {
   scope?: string;
   owner?: string;
 }): GovernanceNode {
-  return {
+  const node: GovernanceNode = {
     id: options.id,
     name: options.name ?? options.id,
-    kind: 'typescript-workspace-project',
+    kind: 'project',
     technology: 'typescript',
     sourceSystem: options.sourceSystem ?? 'pnpm',
     root: options.root ?? `packages/${options.id}`,
@@ -98,18 +100,29 @@ export function createTypeScriptProjectNode(options: {
           },
         }
       : {}),
-    metadata: {
-      typescript: {
-        workspaceProject: {
-          id: options.id,
-        },
-      },
-      packageManager: {
-        packageManager: options.sourceSystem ?? 'pnpm',
-        ...(options.packageJson ? { packageJson: options.packageJson } : {}),
-      },
-    },
+    metadata: {},
   };
+
+  return attachTypeScriptGovernanceModelExpansion(node, {
+    kind: 'node',
+    technology: 'typescript',
+    nodeKind: 'workspace-project',
+    packageManager: options.sourceSystem ?? 'pnpm',
+    ...(options.packageJson ? { packageJson: options.packageJson } : {}),
+    packageManagerPackage: {
+      workspace: true,
+      external: false,
+      ...(options.packageJson &&
+      typeof options.packageJson.name === 'string' &&
+      options.packageJson.name.length > 0
+        ? { packageName: options.packageJson.name }
+        : {}),
+    },
+    workspaceProject: {
+      id: options.id,
+      projectRoot: options.root ?? `packages/${options.id}`,
+    },
+  });
 }
 
 export function createTsconfigNode(
@@ -119,45 +132,54 @@ export function createTsconfigNode(
   } = {},
 ): GovernanceNode {
   const configPath = options.path ?? 'tsconfig.base.json';
-
-  return {
+  const node: GovernanceNode = {
     id: `tsconfig:${configPath}`,
     name: configPath.split('/').at(-1) ?? configPath,
-    kind: 'typescript-tsconfig',
+    kind: 'resource',
     technology: 'typescript',
     sourceSystem: 'typescript',
     root: '.',
     path: configPath,
     tags: [],
-    metadata: {
-      typescript: {
-        tsconfig: {
-          configFile: configPath,
-          pathAliases: options.aliases ?? {},
-        },
-      },
-    },
+    metadata: {},
   };
+
+  return attachTypeScriptGovernanceModelExpansion(node, {
+    kind: 'node',
+    technology: 'typescript',
+    nodeKind: 'tsconfig',
+    tsconfig: {
+      configFile: configPath,
+      pathAliases: options.aliases ?? {},
+    },
+  });
 }
 
 export function createExternalPackageNode(options: {
   name: string;
   packageManager?: 'pnpm' | 'npm' | 'yarn';
 }): GovernanceNode {
-  return {
+  const node: GovernanceNode = {
     id: `package:${options.name}`,
     name: options.name,
-    kind: 'package-manager-package',
+    kind: 'resource',
     sourceSystem: options.packageManager ?? 'pnpm',
     tags: [],
-    metadata: {
-      packageManager: {
-        packageManager: options.packageManager ?? 'pnpm',
-        external: true,
-        packageName: options.name,
-      },
-    },
+    metadata: {},
   };
+
+  return attachTypeScriptGovernanceModelExpansion(node, {
+    kind: 'node',
+    technology: 'typescript',
+    nodeKind: 'package-manager-package',
+    packageManager: options.packageManager ?? 'pnpm',
+    packageName: options.name,
+    packageManagerPackage: {
+      external: true,
+      workspace: false,
+      packageName: options.name,
+    },
+  });
 }
 
 export function createImportRelation(options: {
@@ -168,22 +190,26 @@ export function createImportRelation(options: {
   importKind?: 'static-import' | 're-export' | 'dynamic-import';
   external?: boolean;
 }): GovernanceRelation {
-  return {
+  const relation: GovernanceRelation = {
     id: `typescript:import:${options.sourceNodeId}->${options.targetNodeId}:${options.specifier ?? 'unknown'}`,
     sourceNodeId: options.sourceNodeId,
     targetNodeId: options.targetNodeId,
-    kind: 'import',
-    metadata: {
-      typescript: {
-        import: {
-          ...(options.sourceFile ? { sourceFile: options.sourceFile } : {}),
-          ...(options.specifier ? { specifier: options.specifier } : {}),
-          importKind: options.importKind ?? 'static-import',
-          external: options.external ?? false,
-        },
-      },
-    },
+    kind: 'dependency',
+    metadata: {},
   };
+
+  return attachTypeScriptGovernanceModelExpansion(relation, {
+    kind: 'relation',
+    technology: 'typescript',
+    relationKind: 'import',
+    ...(options.specifier ? { importSpecifiers: [options.specifier] } : {}),
+    import: {
+      ...(options.sourceFile ? { sourceFile: options.sourceFile } : {}),
+      ...(options.specifier ? { specifier: options.specifier } : {}),
+      importKind: options.importKind ?? 'static-import',
+      external: options.external ?? false,
+    },
+  });
 }
 
 export function createDependencyRelation(options: {
@@ -198,21 +224,26 @@ export function createDependencyRelation(options: {
   specifier?: string;
   packageManager?: 'pnpm' | 'npm' | 'yarn';
 }): GovernanceRelation {
-  return {
+  const relation: GovernanceRelation = {
     id: `typescript:dependency:${options.sourceNodeId}->${options.targetNodeId}:${options.dependencyType ?? 'dependencies'}`,
     sourceNodeId: options.sourceNodeId,
     targetNodeId: options.targetNodeId,
     kind: 'dependency',
-    metadata: {
-      packageManager: {
-        packageManager: options.packageManager ?? 'pnpm',
-        dependencyType: options.dependencyType ?? 'dependencies',
-        packageName:
-          options.packageName ?? options.targetNodeId.replace(/^package:/u, ''),
-        specifier: options.specifier ?? '^1.0.0',
-      },
-    },
+    metadata: {},
   };
+
+  return attachTypeScriptGovernanceModelExpansion(relation, {
+    kind: 'relation',
+    technology: 'typescript',
+    relationKind: 'package-dependency',
+    packageDependency: {
+      packageManager: options.packageManager ?? 'pnpm',
+      dependencyType: options.dependencyType ?? 'dependencies',
+      packageName:
+        options.packageName ?? options.targetNodeId.replace(/^package:/u, ''),
+      specifier: options.specifier ?? '^1.0.0',
+    },
+  });
 }
 
 export function createPathMappingRelation(options: {
@@ -222,19 +253,22 @@ export function createPathMappingRelation(options: {
   target: string;
   tsconfig?: string;
 }): GovernanceRelation {
-  return {
+  const relation: GovernanceRelation = {
     id: `typescript:path-mapping:${options.tsconfigNodeId}->${options.targetNodeId}:${options.alias}`,
     sourceNodeId: options.tsconfigNodeId,
     targetNodeId: options.targetNodeId,
-    kind: 'path-mapping',
-    metadata: {
-      typescript: {
-        pathMapping: {
-          alias: options.alias,
-          target: options.target,
-          tsconfig: options.tsconfig ?? 'tsconfig.base.json',
-        },
-      },
-    },
+    kind: 'traceability',
+    metadata: {},
   };
+
+  return attachTypeScriptGovernanceModelExpansion(relation, {
+    kind: 'relation',
+    technology: 'typescript',
+    relationKind: 'path-alias',
+    pathMapping: {
+      alias: options.alias,
+      target: options.target,
+      tsconfig: options.tsconfig ?? 'tsconfig.base.json',
+    },
+  });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,6 +35,7 @@ __metadata:
   resolution: "@anarchitects/governance-adapter-typescript@workspace:packages/governance/adapter-typescript"
   dependencies:
     "@anarchitects/governance-core": "npm:^0.3.0"
+    "@anarchitects/governance-extension-typescript": "npm:^0.1.2"
     minimatch: "npm:^10.1.1"
     typescript: "npm:~5.9.2"
     yaml: "npm:^2.8.1"
@@ -66,7 +67,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@anarchitects/governance-extension-typescript@workspace:packages/governance/extension-typescript":
+"@anarchitects/governance-extension-typescript@npm:^0.1.2, @anarchitects/governance-extension-typescript@workspace:packages/governance/extension-typescript":
   version: 0.0.0-use.local
   resolution: "@anarchitects/governance-extension-typescript@workspace:packages/governance/extension-typescript"
   dependencies:


### PR DESCRIPTION
closes #362