### PR TITLE
docs(governance-extension-typescript,governance-adapter-typescript,governance-extension-dbt,governance-adapter-dbt,governance-core,governance-cli): consolidate core adapter extension host boundary docs

### DIFF
--- a/docs/governance-boundary-contributor-guide.md
+++ b/docs/governance-boundary-contributor-guide.md
@@ -1,0 +1,302 @@
+# Governance Boundary Contributor Guide
+
+Authoritative decision record:
+[ADR 0003: Governance Boundaries for Canonical Core, Adapters, Extensions, and Hosts](./adr/0003-governance-core-adapter-extension-host-boundaries.md)
+
+Use this guide for practical implementation rules. Keep ADR 0003 as the
+authoritative architectural source of truth.
+
+## Boundary Model
+
+Governance uses four ownership layers:
+
+- `@anarchitects/governance-core` owns canonical contracts, canonical profile
+  policy contracts, generic extension runtime contracts, generic
+  extension-owned model expansion envelope contracts, and deterministic
+  evaluation semantics.
+- governance adapters own source extraction, parsing, normalization of
+  genuinely generic facts into Core fields, and emission of extension-owned
+  expansion envelopes.
+- governance extensions own technology-specific interpretation, expansion
+  validation, contract versioning, diagnostics, rule packs, signals, metrics,
+  recommendations, and optional extension config.
+- governance hosts own orchestration, package loading, config routing, runtime
+  context, and output/reporting behavior.
+
+## Core Rules
+
+`@anarchitects/governance-core` owns:
+
+- canonical governance model contracts
+- canonical profile policy contracts
+- generic extension runtime contracts
+- generic extension-owned model expansion envelope contracts
+- deterministic governance evaluation semantics
+
+`@anarchitects/governance-core` must not own:
+
+- TypeScript-specific fields
+- dbt-specific fields
+- Angular-specific fields
+- GitHub-specific fields
+- Nx-specific fields
+- adapter extraction config
+- extension interpretation config
+- host or runtime orchestration config
+
+## Adapter Rules
+
+Adapters own extraction and normalization.
+
+Adapters may:
+
+- read source-system facts
+- normalize genuinely generic facts into Core-owned canonical fields
+- emit extension-owned expansion envelopes using generic Core contracts
+- preserve source provenance and evidence
+
+Adapters must not:
+
+- own extension semantic interpretation
+- import concrete extension implementation packages at runtime
+- runtime-depend on concrete extension packages
+- call extension factory functions
+- put technology-specific config into the canonical profile
+- move technology-specific payload fields into Core canonical contracts
+
+`#371` rule:
+Adapters may emit extension-owned data by protocol shape, but they must build
+generic `GovernanceExtensionModelExpansion<TData>` envelopes through
+`@anarchitects/governance-core` contracts only.
+
+## Extension Rules
+
+Extensions own:
+
+- technology-specific interpretation
+- extension-owned model expansion validation
+- extension-owned contract versioning
+- extension-owned diagnostics, rule packs, signals, metrics, and
+  recommendations
+- optional extension config
+
+Extensions must not:
+
+- own source artifact loading
+- own adapter extraction
+- own host orchestration
+- require adapter-private implementation details
+- require Core to become technology-specific
+
+## Host Rules
+
+Hosts own orchestration and routing.
+
+Hosts may:
+
+- load canonical profiles
+- load adapters
+- load extensions
+- route adapter config to adapter factories
+- route extension config to extension factories
+- pass host or runtime context separately
+- compose Core, adapters, and extensions
+
+Hosts must not:
+
+- put adapter config into canonical profile policy
+- put extension config into canonical profile policy
+- duplicate Core rules or evaluation logic
+- duplicate adapter extraction logic
+- duplicate extension interpretation logic
+
+The current standalone CLI is a host. Future dbt-specific runtimes or hosts
+should follow the same ownership split.
+
+## Config Placement
+
+Canonical profile:
+
+- generic governance policy only
+- technology-neutral rules, policy, and assessment configuration
+
+Adapter config:
+
+- extraction, discovery, and normalization options
+- source artifact paths
+- parser or discovery options
+- adapter-specific validation modes
+
+Extension config:
+
+- interpretation options
+- technology-specific diagnostics, signals, metrics, and recommendation
+  provider options
+- extension-owned semantic tuning
+
+Host or runtime config:
+
+- root paths
+- profile path
+- package loading
+- adapter selection
+- extension selection
+- output, reporting, and CI invocation behavior
+
+## Extension-Owned Expansion Envelopes
+
+Core owns the envelope shape:
+
+```ts
+type GovernanceExtensionModelExpansion<TData> = {
+  extensionId: string;
+  contractVersion: string;
+  data: TData;
+  diagnostics?: readonly GovernanceExtensionContractIssue[];
+  metadata?: Record<string, unknown>;
+};
+```
+
+Practical rules:
+
+- Core owns the envelope and generic carriers such as `workspace.extensions`.
+- The extension owns the payload schema, semantics, validation, and versioning.
+- The adapter may emit the payload by agreed protocol shape.
+- The host may route extension config separately.
+- Core treats the extension-owned `data` payload as opaque unless a generic
+  Core contract explicitly says otherwise.
+
+## TypeScript Example
+
+Canonical profile:
+
+```json
+{
+  "name": "frontend-policy",
+  "rules": {
+    "layering": {
+      "enabled": true
+    }
+  }
+}
+```
+
+Host config:
+
+```json
+{
+  "profile": "./governance.profile.json",
+  "adapter": "@anarchitects/governance-adapter-typescript",
+  "extensions": ["@anarchitects/governance-extension-typescript"],
+  "adapterOptions": {
+    "@anarchitects/governance-adapter-typescript": {
+      "discoveryConfig": {
+        "projects": [{ "pattern": "packages/*" }]
+      }
+    }
+  },
+  "extensionOptions": {
+    "@anarchitects/governance-extension-typescript": {
+      "signals": {
+        "importGraph": {
+          "enabled": true
+        }
+      }
+    }
+  }
+}
+```
+
+Adapter-emitted extension envelope:
+
+```ts
+import type { GovernanceExtensionModelExpansion } from '@anarchitects/governance-core';
+
+const expansion: GovernanceExtensionModelExpansion<{
+  kind: 'node';
+  technology: 'typescript';
+  nodeKind: 'workspace-project';
+}> = {
+  extensionId: 'governance-extension:typescript',
+  contractVersion: '1',
+  data: {
+    kind: 'node',
+    technology: 'typescript',
+    nodeKind: 'workspace-project',
+  },
+};
+```
+
+Contributor note:
+The adapter emits the TypeScript payload shape without importing
+`@anarchitects/governance-extension-typescript`.
+
+## dbt Example
+
+Canonical profile:
+
+```json
+{
+  "name": "dbt-policy",
+  "rules": {
+    "ownership-required": {
+      "enabled": true
+    }
+  }
+}
+```
+
+Runtime or host config:
+
+```json
+{
+  "profile": "./governance.profile.json",
+  "adapter": "@anarchitects/governance-adapter-dbt",
+  "extensions": ["@anarchitects/governance-extension-dbt"],
+  "adapterOptions": {
+    "@anarchitects/governance-adapter-dbt": {
+      "paths": {
+        "projectDir": "./analytics",
+        "manifestPath": "./analytics/target/manifest.json"
+      },
+      "validationMode": "strict"
+    }
+  },
+  "extensionOptions": {
+    "@anarchitects/governance-extension-dbt": {
+      "signals": {},
+      "metrics": {}
+    }
+  }
+}
+```
+
+dbt adapter envelope:
+
+```ts
+import type { GovernanceExtensionModelExpansion } from '@anarchitects/governance-core';
+
+const expansion: GovernanceExtensionModelExpansion<{
+  kind: 'workspace';
+  technology: 'dbt';
+  projectName: string;
+}> = {
+  extensionId: 'governance-extension:dbt',
+  contractVersion: '1',
+  data: {
+    kind: 'workspace',
+    technology: 'dbt',
+    projectName: 'analytics',
+  },
+};
+```
+
+Contributor notes:
+
+- The dbt adapter emits dbt extension-owned envelopes without importing
+  `@anarchitects/governance-extension-dbt`.
+- A future `governance-runtime-dbt` should compose Core, the dbt adapter, and
+  the dbt extension.
+- A future dbt host should own dbt-native UX and artifact lifecycle
+  orchestration instead of moving those concerns into Core, the adapter, or
+  the extension.

--- a/docs/governance-documentation-structure.md
+++ b/docs/governance-documentation-structure.md
@@ -26,6 +26,7 @@ Suggested structure:
 
 ```text
 docs/
+  governance-boundary-contributor-guide.md
   governance-package-layout.md
   governance-package-conventions.md
   governance-package-boundaries.md
@@ -34,11 +35,19 @@ docs/
 packages/governance/*/README.md
 ```
 
-Repository-level Governance docs should own shared concepts, ownership boundaries, dependency direction, release sequencing, and documentation structure guidance.
+Repository-level Governance docs should own shared concepts, ownership
+boundaries, dependency direction, config placement, release sequencing, and
+documentation structure guidance.
 
 Accepted package-boundary decisions should live under `docs/adr/` and be linked from the supporting Governance docs.
 
-Package-level READMEs should own package-specific purpose, usage, configuration, compatibility notes, and links back to the shared Governance docs where needed.
+Package-level READMEs should own package-specific purpose, usage,
+configuration, compatibility notes, and links back to the shared Governance
+docs where needed.
+
+The practical contributor reference for Core vs adapter vs extension vs host
+implementation should live once at the repository level and be linked from
+package READMEs rather than copied into each package.
 
 ## Package README Expectations
 
@@ -163,6 +172,7 @@ Ownership boundaries and dependency direction should remain documented at the re
 Package docs should link to the shared Governance docs for:
 
 - Community package ownership boundaries
+- practical Core/adapter/extension/host contributor guidance
 - forbidden Nx-specific responsibilities
 - allowed and forbidden dependency direction
 - Community-first release direction

--- a/docs/governance-package-boundaries.md
+++ b/docs/governance-package-boundaries.md
@@ -11,6 +11,9 @@ This document defines public API and dependency-boundary conventions for future 
 Status:
 Supporting guidance for Governance package boundary work. Accepted architectural source of truth lives in ADR 0001 and ADR 0003.
 
+Practical contributor guide:
+[`docs/governance-boundary-contributor-guide.md`](./governance-boundary-contributor-guide.md)
+
 ## Public API Expectations
 
 Governance packages should expose explicit and intentional public APIs.
@@ -42,15 +45,20 @@ That means:
 Allowed:
 
 - `@anarchitects/governance-cli` -> `@anarchitects/governance-core`
-- `@anarchitects/governance-adapter-typescript` -> `@anarchitects/governance-core`
+- `@anarchitects/governance-adapter-*` -> `@anarchitects/governance-core`
 - `@anarchitects/governance-extension-*` -> `@anarchitects/governance-core`
-- published packages in `anarchitecture-plugins` -> published Governance packages from `anarchitecture-community`
+- future Governance hosts or runtimes -> `@anarchitects/governance-core` plus
+  the concrete adapters and extensions they intentionally orchestrate
+- published packages in `anarchitecture-plugins` -> published Governance
+  packages from `anarchitecture-community`
 
 Forbidden:
 
 - `@anarchitects/governance-core` -> CLI packages
 - `@anarchitects/governance-core` -> adapter packages
 - `@anarchitects/governance-core` -> extension runtime implementations
+- `@anarchitects/governance-adapter-*` -> concrete extension implementation
+  packages at runtime
 - any Community Governance package -> Nx APIs
 - any Community Governance package -> `@anarchitects/governance-adapter-nx`
 - any Community Governance package -> `@anarchitects/nx-governance`
@@ -61,10 +69,14 @@ Forbidden:
 
 - owns canonical contracts
 - owns deterministic governance logic
+- owns generic extension runtime and model expansion envelope contracts
 - must remain platform-independent
 - must not know about Nx
 - must not know about CLI runtime concerns
-- must not know about TypeScript workspace scanning internals
+- must not know about TypeScript, dbt, GitHub, Angular, or other
+  technology-specific payload schemas
+- must not own adapter extraction config, extension interpretation config, or
+  host orchestration config
 
 Core is the canonical model layer. It should define the shapes that adapters and hosts normalize into, not consume host-specific extraction models.
 
@@ -74,23 +86,32 @@ Core is the canonical model layer. It should define the shapes that adapters and
 
 - owns standalone runtime orchestration
 - may depend on Core
-- may accept concrete adapters only through Core-owned contracts
+- may accept concrete adapters only through Core-owned contracts and
+  host-routed package loading
 - may format output and handle process exit behavior
 - must not become a source of canonical Governance contracts
 - must not depend directly on concrete adapter packages
+- must not fold adapter or extension options into the canonical profile
 
 If the CLI needs a reusable contract, that contract belongs in Core rather than in CLI-specific modules.
 
 ## Adapter Boundary Rules
 
-`@anarchitects/governance-adapter-typescript`:
+`@anarchitects/governance-adapter-*`:
 
-- owns TypeScript workspace extraction logic
+- own source extraction and normalization
 - may depend on Governance Core contracts
-- must normalize into canonical `GovernanceWorkspace` structures
-- must not leak adapter-specific models into Core
+- may emit extension-owned expansions through generic Core-owned envelopes
+- must normalize into canonical Core structures
+- must preserve source provenance when useful
+- must not import concrete extension implementation packages at runtime
+- must not runtime-depend on concrete extension implementation packages
+- must not call extension factory functions
+- must not move technology-specific payload fields into Core
 
-The adapter may perform host-specific parsing and discovery internally, but its public output should align with canonical Core contracts rather than custom transport shapes.
+Adapters may emit extension-owned data by protocol shape, but they must build
+`GovernanceExtensionModelExpansion<TData>` envelopes through
+`@anarchitects/governance-core` contracts only.
 
 ## Extension Boundary Rules
 
@@ -98,10 +119,25 @@ The adapter may perform host-specific parsing and discovery internally, but its 
 
 - may extend Governance behavior
 - may contribute rules, signals, presets, and diagnostics
+- own technology-specific expansion validation and versioning
 - must remain platform-independent unless explicitly documented otherwise
-- must not own Nx runtime behavior
+- must not own source artifact loading
+- must not own adapter extraction
+- must not own host orchestration
 
 Extensions should plug into Core contracts and extension points rather than inventing parallel models.
+
+## Config Placement
+
+Use the config split from ADR 0003 and the contributor guide:
+
+- canonical profile: generic governance policy only
+- adapter config: extraction, discovery, normalization, paths, validation mode
+- extension config: interpretation, diagnostics, signals, metrics,
+  recommendations
+- host config: orchestration, loading, runtime context, reporting
+
+Technology-specific options do not belong in the canonical profile.
 
 ## Forbidden Dependencies
 

--- a/docs/governance-package-conventions.md
+++ b/docs/governance-package-conventions.md
@@ -53,6 +53,7 @@ Governance packages should be:
 - clean in published npm artifacts
 
 See `docs/governance-package-boundaries.md` for Governance-specific public API and dependency-boundary rules.
+See `docs/governance-boundary-contributor-guide.md` for Core vs adapter vs extension vs host ownership and config placement.
 See `docs/governance-release-conventions.md` for release sequencing and versioning expectations.
 See `docs/governance-documentation-structure.md` for package README and documentation placement expectations.
 
@@ -138,6 +139,35 @@ Minimum expectations:
 - externalize dependencies appropriately so build output reflects the intended public package boundary
 
 Large manual validation assets should remain outside publishable outputs. If a fixture is needed for tests, it should still be prevented from appearing in the packed artifact.
+
+## Boundary-Conscious Dependency Conventions
+
+Package manifests should reinforce the ownership split from ADR 0003.
+
+Use these rules:
+
+- Core stays technology-agnostic and does not add ecosystem-specific runtime
+  dependencies for convenience.
+- Adapters depend on `@anarchitects/governance-core` for canonical contracts
+  and generic extension envelope contracts.
+- Adapters must not add runtime dependencies on concrete extension
+  implementation packages.
+- Extensions depend on `@anarchitects/governance-core` and own their
+  technology-specific validation and interpretation.
+- Hosts or runtimes may orchestrate concrete adapters and extensions, but that
+  orchestration boundary does not move into Core, adapters, or extensions.
+
+## Configuration Conventions
+
+Governance package docs and examples should keep configuration ownership
+explicit:
+
+- canonical profile examples stay technology-neutral
+- adapter examples show extraction, discovery, path, or validation options
+- extension examples show interpretation and provider options
+- host examples show package selection, runtime context, and reporting options
+
+Do not place adapter or extension options in canonical profile examples.
 
 ## Package Validation Expectations
 

--- a/packages/governance/adapter-dbt/README.md
+++ b/packages/governance/adapter-dbt/README.md
@@ -10,6 +10,8 @@ evaluate governance rules, compute scores, or implement dbt host behavior.
 Package boundaries follow
 [ADR 0001](../../../docs/adr/0001-governance-package-boundaries.md) and
 [ADR 0003](../../../docs/adr/0003-governance-core-adapter-extension-host-boundaries.md).
+Practical contributor guidance lives in
+[`docs/governance-boundary-contributor-guide.md`](../../../docs/governance-boundary-contributor-guide.md).
 
 ## Public API
 
@@ -94,6 +96,7 @@ The canonical adapter output is:
 - `capabilities`
 - `diagnostics`
 - `metadata`
+- `metadata.dbt`
 - `extensions`
 
 Canonical governance facts stay in first-class Core fields when they are
@@ -161,6 +164,13 @@ The dbt adapter does not own:
 - runtime composition
 - host UX, CI orchestration, or dbt command execution
 
+Adapter contributor rules:
+
+- do not import `@anarchitects/governance-extension-dbt` at runtime
+- do not add a runtime dependency on the dbt extension package
+- do not call extension factory helpers from the adapter
+- emit dbt extension data through Core-owned generic envelope contracts
+
 Future `@anarchitects/governance-runtime-dbt` should compose:
 
 - canonical governance profile config
@@ -186,17 +196,18 @@ extension layers instead of collapsing everything into one profile surface.
   "adapter": "@anarchitects/governance-adapter-dbt",
   "extensions": ["@anarchitects/governance-extension-dbt"],
   "adapterOptions": {
-    "dbt": {
+    "@anarchitects/governance-adapter-dbt": {
       "paths": {
         "projectDir": "./analytics",
         "manifestPath": "./analytics/target/manifest.json"
-      }
+      },
+      "validationMode": "strict"
     }
   },
   "extensionOptions": {
-    "dbt": {
+    "@anarchitects/governance-extension-dbt": {
       "signals": {},
-      "rules": {}
+      "metrics": {}
     }
   }
 }

--- a/packages/governance/adapter-typescript/README.md
+++ b/packages/governance/adapter-typescript/README.md
@@ -15,6 +15,8 @@ graph.
 Package boundaries follow
 [ADR 0001](../../../docs/adr/0001-governance-package-boundaries.md) and
 [ADR 0003](../../../docs/adr/0003-governance-core-adapter-extension-host-boundaries.md).
+Practical contributor guidance lives in
+[`docs/governance-boundary-contributor-guide.md`](../../../docs/governance-boundary-contributor-guide.md).
 
 ## Key Concepts
 
@@ -220,6 +222,13 @@ The adapter owns extraction and deterministic normalization only.
   expansion envelopes.
 - Adapter-specific extraction config remains adapter/host-owned and does not
   expand the canonical Governance profile.
+
+Adapter contributor rules:
+
+- do not import `@anarchitects/governance-extension-typescript` at runtime
+- do not add a runtime dependency on the TypeScript extension package
+- do not call extension factory helpers from the adapter
+- emit TypeScript expansion data through Core-owned generic envelope contracts
 
 ## Related Packages
 

--- a/packages/governance/cli/README.md
+++ b/packages/governance/cli/README.md
@@ -13,6 +13,8 @@ automation script without writing a custom host.
 Package boundaries follow
 [ADR 0001](../../../docs/adr/0001-governance-package-boundaries.md) and
 [ADR 0003](../../../docs/adr/0003-governance-core-adapter-extension-host-boundaries.md).
+Practical contributor guidance lives in
+[`docs/governance-boundary-contributor-guide.md`](../../../docs/governance-boundary-contributor-guide.md).
 
 ## Key Concepts
 
@@ -158,7 +160,7 @@ Use `agov.config.json` or `governance.config.json` for host-owned layering:
 }
 ```
 
-In that split:
+In that layering:
 
 - `profile` remains canonical Core policy
 - `adapterOptions` routes only to adapter creation/loading
@@ -185,10 +187,35 @@ TypeScript example:
 
 dbt-oriented note:
 
-- future dbt hosts should apply the same split between canonical profile,
+- future dbt hosts should apply the same ownership layering between canonical profile,
   dbt adapter config, dbt extension config, and dbt runtime/host options
 - dbt-specific extraction and interpretation options should not be folded into
   the canonical profile
+
+dbt example:
+
+```json
+{
+  "profile": "./governance.profile.json",
+  "adapter": "@anarchitects/governance-adapter-dbt",
+  "extensions": ["@anarchitects/governance-extension-dbt"],
+  "adapterOptions": {
+    "@anarchitects/governance-adapter-dbt": {
+      "paths": {
+        "projectDir": "./analytics",
+        "manifestPath": "./analytics/target/manifest.json"
+      },
+      "validationMode": "strict"
+    }
+  },
+  "extensionOptions": {
+    "@anarchitects/governance-extension-dbt": {
+      "signals": {},
+      "metrics": {}
+    }
+  }
+}
+```
 
 ### Inspection Commands
 

--- a/packages/governance/core/README.md
+++ b/packages/governance/core/README.md
@@ -18,6 +18,8 @@ Use this package when you are building:
 Package boundaries follow
 [ADR 0001](../../../docs/adr/0001-governance-package-boundaries.md) and
 [ADR 0003](../../../docs/adr/0003-governance-core-adapter-extension-host-boundaries.md).
+Practical contributor guidance lives in
+[`docs/governance-boundary-contributor-guide.md`](../../../docs/governance-boundary-contributor-guide.md).
 
 ## Key Concepts
 
@@ -135,6 +137,7 @@ This package owns:
 - deterministic rule evaluation, metrics, health, and assessment assembly
 - generic built-in rule packs
 - extension contracts, capability contracts, and registration helpers
+- generic extension-owned model expansion envelope contracts
 - deterministic AI handoff payload builders over canonical assessment data
 
 This package does not own:
@@ -147,6 +150,7 @@ This package does not own:
 - host-specific configuration discovery
 - adapter-specific extraction or normalization configuration
 - extension-specific interpretation configuration
+- host or runtime orchestration configuration
 
 ## Boundary Model
 
@@ -165,6 +169,10 @@ When technology-specific or source-specific facts still need to travel through
 Core contracts, they should remain opaque in versioned extension-owned
 expansion envelopes, capability payloads, or extension host `options` until a
 stable generic Core contract exists.
+
+Contributor rule:
+If a field is TypeScript-specific, dbt-specific, or otherwise technology-owned,
+do not place it in Core just because multiple packages need to carry it.
 
 ## Usage
 

--- a/packages/governance/extension-dbt/README.md
+++ b/packages/governance/extension-dbt/README.md
@@ -11,6 +11,8 @@ diagnostics, signals, rule results, measurements, and recommendations.
 Package boundaries follow
 [ADR 0001](../../../docs/adr/0001-governance-package-boundaries.md) and
 [ADR 0003](../../../docs/adr/0003-governance-core-adapter-extension-host-boundaries.md).
+Practical contributor guidance lives in
+[`docs/governance-boundary-contributor-guide.md`](../../../docs/governance-boundary-contributor-guide.md).
 
 ## Public API
 
@@ -115,6 +117,32 @@ await registerLoadedGovernanceExtensionsWithDiagnostics(context, [
 ]);
 ```
 
+## dbt-Owned Model Expansions
+
+This package owns the dbt expansion payload schema carried through Core's
+generic `extensions` envelope:
+
+```ts
+{
+  extensionId: 'governance-extension:dbt',
+  contractVersion: '1',
+  data: {
+    kind: 'node' | 'relation' | 'workspace' | 'runtime-context',
+    technology: 'dbt',
+    // dbt-owned fields
+  },
+}
+```
+
+Ownership rules:
+
+- Core owns the generic carrier and envelope shape.
+- This package owns dbt payload validation and versioning.
+- The dbt adapter may emit the payload by protocol shape without importing the
+  extension runtime.
+- Hosts route dbt-specific interpretation config separately through extension
+  options or `GovernanceExtensionHostContext.options`.
+
 ## Related Packages
 
 - `@anarchitects/governance-core` owns the canonical node/relation contracts.
@@ -133,8 +161,10 @@ This extension owns:
 This extension does not own:
 
 - raw dbt artifact loading
+- adapter extraction
 - runtime composition
 - dbt host concerns such as command UX, CI orchestration, or reporting shells
+- adapter-private implementation details
 
 Future `@anarchitects/governance-runtime-dbt` should compose Core, the dbt
 adapter, and this extension. Future dbt host packages should own dbt-native

--- a/packages/governance/extension-typescript/README.md
+++ b/packages/governance/extension-typescript/README.md
@@ -14,6 +14,8 @@ extension contributions separately from TypeScript workspace extraction.
 Package boundaries follow
 [ADR 0001](../../../docs/adr/0001-governance-package-boundaries.md) and
 [ADR 0003](../../../docs/adr/0003-governance-core-adapter-extension-host-boundaries.md).
+Practical contributor guidance lives in
+[`docs/governance-boundary-contributor-guide.md`](../../../docs/governance-boundary-contributor-guide.md).
 
 ## Key Concepts
 
@@ -143,7 +145,7 @@ Validation and versioning rules:
 - Future incompatible TypeScript expansion changes must increment the contract
   version in this package instead of changing Core.
 
-Ownership split:
+Ownership boundaries:
 
 - Canonical facts such as ownership, domain, layer, and scope remain Core
   inputs when they are genuinely architectural.
@@ -153,6 +155,14 @@ Ownership split:
 - Hosts route runtime config separately through extension options or
   `GovernanceExtensionHostContext.options`; that config does not belong in the
   canonical Governance profile.
+
+TypeScript extension contributor rules:
+
+- own TypeScript expansion validation and contract versioning here
+- own TypeScript-specific diagnostics, signals, metrics, and recommendations
+- do not own TypeScript workspace extraction
+- do not require adapter-private implementation details
+- do not move TypeScript-specific payload fields into Core
 
 ## Related Packages
 


### PR DESCRIPTION
closes #364