### PR TITLE
fix(governance-adapter-typescript): soften default no-match discovery diagnostics

### DIFF
--- a/packages/governance/adapter-typescript/src/diagnostics.ts
+++ b/packages/governance/adapter-typescript/src/diagnostics.ts
@@ -235,12 +235,14 @@ export function invalidDiscoveryPatternDiagnostic(
 export function discoveryPatternNoMatchesDiagnostic(
   pattern: string,
   path: string,
+  metadata?: Record<string, unknown>,
 ): TypeScriptWorkspaceDetectionDiagnostic {
   return {
     code: 'governance.typescript_adapter.discovery_pattern_no_matches',
     message: `Discovery pattern "${pattern}" did not match any package roots.`,
     source: DIAGNOSTIC_SOURCE,
     path,
+    ...(metadata ? { metadata } : {}),
   };
 }
 

--- a/packages/governance/adapter-typescript/src/project-discovery.spec.ts
+++ b/packages/governance/adapter-typescript/src/project-discovery.spec.ts
@@ -287,6 +287,37 @@ describe('TypeScript project discovery', () => {
     ]);
   });
 
+  it('marks default no-match patterns as detail-only diagnostics', () => {
+    const result = discoverTypeScriptProjects(
+      workspace({
+        packageRoots: ['packages/core'],
+      }),
+      {
+        projects: [
+          {
+            pattern: 'apps/*',
+            name: '{segment:1}',
+            configuredBy: 'default',
+          },
+        ],
+      },
+    );
+
+    expect(result.projects).toEqual([]);
+    expect(result.diagnostics).toEqual([
+      {
+        code: 'governance.typescript_adapter.discovery_pattern_no_matches',
+        message: 'Discovery pattern "apps/*" did not match any package roots.',
+        source: 'governance.typescript_adapter',
+        path: '/projects/0/pattern',
+        metadata: {
+          configuredBy: 'default',
+          visibility: 'detail',
+        },
+      },
+    ]);
+  });
+
   it('reports invalid discovery patterns deterministically', () => {
     const result = discoverTypeScriptProjects(
       workspace({

--- a/packages/governance/adapter-typescript/src/project-discovery.ts
+++ b/packages/governance/adapter-typescript/src/project-discovery.ts
@@ -84,7 +84,16 @@ export function discoverTypeScriptProjects(
 
     if (matches.length === 0) {
       diagnostics.push(
-        discoveryPatternNoMatchesDiagnostic(pattern, `${rulePath}/pattern`),
+        discoveryPatternNoMatchesDiagnostic(
+          pattern,
+          `${rulePath}/pattern`,
+          rule.configuredBy === 'default'
+            ? {
+                configuredBy: 'default',
+                visibility: 'detail',
+              }
+            : undefined,
+        ),
       );
       return;
     }

--- a/packages/governance/adapter-typescript/src/types.ts
+++ b/packages/governance/adapter-typescript/src/types.ts
@@ -58,6 +58,7 @@ export interface TypeScriptProjectDiscoveryRule {
   name?: string;
   tags?: string[];
   projection?: TypeScriptProjectDiscoveryProjection;
+  configuredBy?: 'default' | 'user';
 }
 
 export interface TypeScriptProjectDiscoveryConfig {

--- a/packages/governance/adapter-typescript/src/workspace-adapter.spec.ts
+++ b/packages/governance/adapter-typescript/src/workspace-adapter.spec.ts
@@ -179,6 +179,57 @@ describe('generic Governance adapter exports', () => {
     expect(typedDefault.id).toBe('governance-adapter:typescript');
   });
 
+  it('keeps default discovery no-match diagnostics as detail-only infos', () => {
+    const workspaceRoot = materializeFixture('pnpm');
+    const result =
+      createGovernanceWorkspaceAdapter().loadWorkspace(workspaceRoot);
+    const diagnostics = result.diagnostics ?? [];
+
+    const noMatchDiagnostics = diagnostics.filter(
+      (diagnostic) =>
+        diagnostic.code ===
+        'governance.typescript_adapter.discovery_pattern_no_matches',
+    );
+
+    expect(noMatchDiagnostics.length).toBeGreaterThan(0);
+    expect(
+      noMatchDiagnostics.every(
+        (diagnostic) =>
+          diagnostic.severity === 'info' &&
+          diagnostic.kind === 'observation' &&
+          diagnostic.metadata?.configuredBy === 'default' &&
+          diagnostic.metadata?.visibility === 'detail',
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps explicit no-match discovery diagnostics visible as warnings', () => {
+    const workspaceRoot = materializeFixture('pnpm');
+    const result = createTypeScriptWorkspaceAdapter({
+      discoveryConfig: {
+        projects: [
+          {
+            pattern: 'libs/*',
+            name: '{segment:1}',
+          },
+        ],
+      },
+      packageGovernanceMetadataConfig:
+        DEFAULT_TYPESCRIPT_PACKAGE_GOVERNANCE_METADATA_CONFIG,
+    }).loadWorkspace(workspaceRoot);
+    const diagnostics = result.diagnostics ?? [];
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'governance.typescript_adapter.discovery_pattern_no_matches',
+        severity: 'warning',
+        kind: 'warning',
+        category: 'adapter',
+      }),
+    ]);
+    expect(diagnostics[0]?.metadata).toBeUndefined();
+  });
+
   it('includes metadata diagnostics in canonical loadWorkspace results and continues discovery', () => {
     const workspaceRoot = materializeFixture('pnpm');
     writeJsonFile(path.join(workspaceRoot, 'packages', 'customer'), {

--- a/packages/governance/adapter-typescript/src/workspace-adapter.ts
+++ b/packages/governance/adapter-typescript/src/workspace-adapter.ts
@@ -55,16 +55,16 @@ export interface CreateGovernanceWorkspaceAdapterOptions {
 
 export const DEFAULT_TYPESCRIPT_PROJECT_DISCOVERY_CONFIG = {
   projects: [
-    { pattern: 'packages/*' },
-    { pattern: 'packages/*/*' },
-    { pattern: 'apps/*' },
-    { pattern: 'apps/*/*' },
-    { pattern: 'libs/*' },
-    { pattern: 'libs/*/*' },
-    { pattern: 'services/*' },
-    { pattern: 'services/*/*' },
-    { pattern: 'tools/*' },
-    { pattern: 'tools/*/*' },
+    { pattern: 'packages/*', configuredBy: 'default' },
+    { pattern: 'packages/*/*', configuredBy: 'default' },
+    { pattern: 'apps/*', configuredBy: 'default' },
+    { pattern: 'apps/*/*', configuredBy: 'default' },
+    { pattern: 'libs/*', configuredBy: 'default' },
+    { pattern: 'libs/*/*', configuredBy: 'default' },
+    { pattern: 'services/*', configuredBy: 'default' },
+    { pattern: 'services/*/*', configuredBy: 'default' },
+    { pattern: 'tools/*', configuredBy: 'default' },
+    { pattern: 'tools/*/*', configuredBy: 'default' },
   ],
 } satisfies TypeScriptProjectDiscoveryConfig;
 
@@ -766,12 +766,26 @@ function diagnosticSeverity(
   diagnostic: TypeScriptWorkspaceDetectionDiagnostic,
 ): GovernanceDiagnosticSeverity {
   if (
-    diagnostic.code === 'governance.typescript_adapter.no_workspace_indicators'
+    diagnostic.code ===
+      'governance.typescript_adapter.no_workspace_indicators' ||
+    isDefaultDiscoveryNoMatchDiagnostic(diagnostic)
   ) {
     return 'info';
   }
 
   return 'warning';
+}
+
+function isDefaultDiscoveryNoMatchDiagnostic(
+  diagnostic: TypeScriptWorkspaceDetectionDiagnostic,
+): boolean {
+  const metadata = asRecord(diagnostic.metadata);
+
+  return (
+    diagnostic.code ===
+      'governance.typescript_adapter.discovery_pattern_no_matches' &&
+    metadata?.configuredBy === 'default'
+  );
 }
 
 function diagnosticKind(

--- a/packages/governance/cli/src/render-report.spec.ts
+++ b/packages/governance/cli/src/render-report.spec.ts
@@ -392,6 +392,140 @@ describe('agov command report rendering', () => {
     expect(markdownTableSpy).toHaveBeenCalled();
   });
 
+  it('keeps detail-only diagnostics out of normal workspace validate rendering', async () => {
+    const workspaceValidateResult = await runAgovWorkspaceValidate({
+      workspaceAdapter: {
+        id: 'test-adapter:workspace-validate-detail-only',
+        loadWorkspace() {
+          return {
+            workspaceId: 'diagnostic-workspace',
+            workspaceName: 'diagnostic-workspace',
+            workspaceRoot: '.',
+            nodes: [
+              {
+                id: 'app',
+                name: 'app',
+                kind: 'application',
+                root: 'apps/app',
+              },
+            ],
+            relations: [],
+            diagnostics: [
+              {
+                code: 'governance.typescript_adapter.discovery_pattern_no_matches',
+                message:
+                  'Discovery pattern "libs/*" did not match any package roots.',
+                severity: 'info',
+                kind: 'observation',
+                category: 'adapter',
+                metadata: {
+                  configuredBy: 'default',
+                  visibility: 'detail',
+                },
+              },
+            ],
+          };
+        },
+      },
+      workspaceAdapterInput: '.',
+    });
+
+    const textRendered = renderAgovWorkspaceValidateReport(
+      workspaceValidateResult,
+      'text',
+    );
+    const markdownRendered = renderAgovWorkspaceValidateReport(
+      workspaceValidateResult,
+      'markdown',
+    );
+    const parsed = JSON.parse(
+      renderAgovWorkspaceValidateJson(workspaceValidateResult),
+    ) as {
+      diagnostics: Array<{
+        metadata?: Record<string, unknown>;
+      }>;
+      summary: {
+        diagnosticCount: number;
+      };
+    };
+
+    expect(parsed.summary.diagnosticCount).toBe(1);
+    expect(parsed.diagnostics).toEqual([
+      expect.objectContaining({
+        metadata: {
+          configuredBy: 'default',
+          visibility: 'detail',
+        },
+      }),
+    ]);
+    expect(textRendered).not.toContain('Diagnostics');
+    expect(markdownRendered).not.toContain('## Diagnostics');
+    expect(markdownRendered).toContain('| diagnostic count | 0 |');
+  });
+
+  it('keeps detail-only diagnostics out of normal check rendering while preserving JSON output', async () => {
+    const checkResult = await runAgovCheck({
+      workspaceAdapter: {
+        id: 'test-adapter:check-detail-only',
+        loadWorkspace() {
+          return {
+            workspaceId: 'diagnostic-workspace',
+            workspaceName: 'diagnostic-workspace',
+            workspaceRoot: '.',
+            nodes: [
+              {
+                id: 'app',
+                name: 'app',
+                kind: 'application',
+                root: 'apps/app',
+              },
+            ],
+            relations: [],
+            diagnostics: [
+              {
+                code: 'governance.typescript_adapter.discovery_pattern_no_matches',
+                message:
+                  'Discovery pattern "libs/*" did not match any package roots.',
+                severity: 'info',
+                kind: 'observation',
+                category: 'adapter',
+                metadata: {
+                  configuredBy: 'default',
+                  visibility: 'detail',
+                },
+              },
+            ],
+          };
+        },
+      },
+      workspaceAdapterInput: '.',
+      profilePath: fixturePath(
+        '../tests/fixtures/standalone-cli/passing-profile.json',
+      ),
+    });
+
+    const textRendered = renderAgovCheckReport(checkResult, 'text');
+    const markdownRendered = renderAgovCheckReport(checkResult, 'markdown');
+    const parsed = JSON.parse(renderAgovCheckJson(checkResult)) as {
+      artifacts: {
+        diagnostics: Array<{
+          metadata?: Record<string, unknown>;
+        }>;
+      };
+    };
+
+    expect(parsed.artifacts.diagnostics).toEqual([
+      expect.objectContaining({
+        metadata: {
+          configuredBy: 'default',
+          visibility: 'detail',
+        },
+      }),
+    ]);
+    expect(textRendered).not.toContain('Diagnostics');
+    expect(markdownRendered).not.toContain('## Diagnostics');
+  });
+
   it('keeps dependencies JSON output shape stable', async () => {
     const dependenciesResult = await runAgovDependencies({
       workspacePath: fixturePath(

--- a/packages/governance/cli/src/render-report.ts
+++ b/packages/governance/cli/src/render-report.ts
@@ -290,13 +290,17 @@ function appendDiagnosticsText(
   lines: string[],
   result: AgovCommandResult,
 ): void {
-  if (result.artifacts.diagnostics.length > 0) {
+  const diagnostics = filterDiagnosticsForStandardOutput(
+    result.artifacts.diagnostics,
+  );
+
+  if (diagnostics.length > 0) {
     lines.push('');
     lines.push('Diagnostics');
     lines.push(
       ...reportingPrimitives.renderTwoColumnTextTable({
         headers: ['Diagnostic', 'Details'],
-        rows: result.artifacts.diagnostics.map((diagnostic) => [
+        rows: diagnostics.map((diagnostic) => [
           diagnostic.code,
           formatDiagnosticDetails(diagnostic),
         ]),
@@ -337,13 +341,17 @@ function appendDiagnosticsMarkdown(
   lines: string[],
   result: AgovCommandResult,
 ): void {
-  if (result.artifacts.diagnostics.length > 0) {
+  const diagnostics = filterDiagnosticsForStandardOutput(
+    result.artifacts.diagnostics,
+  );
+
+  if (diagnostics.length > 0) {
     lines.push('');
     lines.push('## Diagnostics');
     lines.push(
       ...reportingPrimitives.renderMarkdownTable({
         headers: ['Diagnostic', 'Details'],
-        rows: result.artifacts.diagnostics.map((diagnostic) => [
+        rows: diagnostics.map((diagnostic) => [
           diagnostic.code,
           formatDiagnosticDetails(diagnostic),
         ]),
@@ -419,6 +427,29 @@ function readDiagnosticStatus(
   return metadataStatus ?? detailsStatus;
 }
 
+function filterDiagnosticsForStandardOutput<T extends { metadata?: unknown }>(
+  diagnostics: readonly T[],
+): T[] {
+  return diagnostics.filter(
+    (diagnostic) => readDiagnosticVisibility(diagnostic) !== 'detail',
+  );
+}
+
+function readDiagnosticVisibility(diagnostic: {
+  metadata?: unknown;
+}): string | undefined {
+  const metadata =
+    typeof diagnostic.metadata === 'object' &&
+    diagnostic.metadata !== null &&
+    !Array.isArray(diagnostic.metadata)
+      ? (diagnostic.metadata as Record<string, unknown>)
+      : undefined;
+
+  return typeof metadata?.visibility === 'string'
+    ? metadata.visibility
+    : undefined;
+}
+
 function renderAgovProfileValidateTable(
   result: AgovProfileValidateResult,
 ): string {
@@ -463,6 +494,9 @@ function renderAgovWorkspaceValidateTable(
   result: AgovWorkspaceValidateResult,
 ): string {
   const lines: string[] = [];
+  const diagnostics = filterDiagnosticsForStandardOutput(
+    result.diagnostics ?? [],
+  );
 
   lines.push('agov workspace validate');
   lines.push('');
@@ -479,7 +513,7 @@ function renderAgovWorkspaceValidateTable(
         ['node count', String(result.summary.nodeCount)],
         ['relation count', String(result.summary.relationCount)],
         ['error count', String(result.summary.errorCount)],
-        ['diagnostic count', String(result.summary.diagnosticCount)],
+        ['diagnostic count', String(diagnostics.length)],
         ['warning count', String(result.summary.warningCount)],
       ],
     }),
@@ -501,13 +535,13 @@ function renderAgovWorkspaceValidateTable(
     );
   }
 
-  if ((result.diagnostics?.length ?? 0) > 0) {
+  if (diagnostics.length > 0) {
     lines.push('');
     lines.push('Diagnostics');
     lines.push(
       ...reportingPrimitives.renderTwoColumnTextTable({
         headers: ['Diagnostic', 'Details'],
-        rows: (result.diagnostics ?? []).map((diagnostic) => [
+        rows: diagnostics.map((diagnostic) => [
           diagnostic.code,
           [
             `message=${diagnostic.message}`,
@@ -844,6 +878,9 @@ function renderAgovWorkspaceValidateMarkdown(
   result: AgovWorkspaceValidateResult,
 ): string {
   const lines: string[] = [];
+  const diagnostics = filterDiagnosticsForStandardOutput(
+    result.diagnostics ?? [],
+  );
 
   lines.push('# agov workspace validate');
   lines.push('');
@@ -860,7 +897,7 @@ function renderAgovWorkspaceValidateMarkdown(
         ['node count', String(result.summary.nodeCount)],
         ['relation count', String(result.summary.relationCount)],
         ['error count', String(result.summary.errorCount)],
-        ['diagnostic count', String(result.summary.diagnosticCount)],
+        ['diagnostic count', String(diagnostics.length)],
         ['warning count', String(result.summary.warningCount)],
       ],
     }),
@@ -881,13 +918,13 @@ function renderAgovWorkspaceValidateMarkdown(
     );
   }
 
-  if ((result.diagnostics?.length ?? 0) > 0) {
+  if (diagnostics.length > 0) {
     lines.push('');
     lines.push('## Diagnostics');
     lines.push(
       ...reportingPrimitives.renderMarkdownTable({
         headers: ['code', 'message', 'source', 'details'],
-        rows: (result.diagnostics ?? []).map((diagnostic) => [
+        rows: diagnostics.map((diagnostic) => [
           diagnostic.code,
           diagnostic.message,
           diagnostic.source ?? 'none',


### PR DESCRIPTION
closes #346