### PR TITLE
fix(governance-extension-dbt): dbt documentation rules should distinguish governed assets from dbt evidence nodes

### DIFF
--- a/packages/governance/extension-dbt/src/rule-pack.spec.ts
+++ b/packages/governance/extension-dbt/src/rule-pack.spec.ts
@@ -370,6 +370,46 @@ describe('dbt architecture basic rule pack', () => {
     );
   });
 
+  it('does not flag documented public models', () => {
+    const workspace = createWorkspace([
+      createProject({
+        id: 'model.analytics.documented_public_orders',
+        layer: 'marts',
+        domain: 'finance',
+        owner: 'finance-platform',
+        publicInterface: true,
+        description: true,
+      }),
+    ]);
+
+    expect(
+      evaluateDbtArchitectureViolations(createInput(workspace)).some(
+        (violation) =>
+          violation.ruleId === 'dbt/public-models-require-description',
+      ),
+    ).toBe(false);
+  });
+
+  it('does not flag dbt test nodes for missing descriptions', () => {
+    const workspace = createWorkspace([
+      createProject({
+        id: 'test.analytics.not_null_public_orders_order_id',
+        resourceType: 'test',
+        publicInterface: true,
+        description: false,
+      }),
+    ]);
+
+    expect(
+      evaluateDbtArchitectureViolations(createInput(workspace)).some(
+        (violation) =>
+          violation.ruleId === 'dbt/public-models-require-description' &&
+          violation.subjectId ===
+            'test.analytics.not_null_public_orders_order_id',
+      ),
+    ).toBe(false);
+  });
+
   it('flags critical models without tests', () => {
     const workspace = createWorkspace([
       createProject({

--- a/packages/governance/extension-dbt/src/rule-pack.ts
+++ b/packages/governance/extension-dbt/src/rule-pack.ts
@@ -463,6 +463,7 @@ function evaluatePublicModelsRequireDescription(
 
   if (
     !config.enabled ||
+    isDbtTestResolution(resolution) ||
     resolution.publicInterface.status !== 'resolved' ||
     resolution.publicInterface.value !== true ||
     (resolution.documentationPresent.status === 'resolved' &&
@@ -877,4 +878,13 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 
 function asString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function isDbtTestResolution(
+  resolution: DbtGovernanceMetadataResolution,
+): boolean {
+  return (
+    resolution.dbtUniqueId?.startsWith('test.') === true ||
+    resolution.governanceNodeId.startsWith('test.')
+  );
 }

--- a/packages/governance/extension-dbt/src/signals.spec.ts
+++ b/packages/governance/extension-dbt/src/signals.spec.ts
@@ -105,6 +105,7 @@ describe('dbt governance signals', () => {
 
   function createProject(options: {
     id: string;
+    resourceType?: 'model' | 'test';
     layer: string;
     domain: string;
     owner?: string;
@@ -134,6 +135,9 @@ describe('dbt governance signals', () => {
         dbt: {
           identity: {
             uniqueId: options.id,
+            ...(options.resourceType
+              ? { resourceType: options.resourceType }
+              : {}),
           },
           resource: {
             tags: options.publicInterface ? ['public'] : [],
@@ -154,7 +158,9 @@ describe('dbt governance signals', () => {
                   },
                 }
               : {}),
-            materialization: 'table',
+            ...(options.resourceType !== 'test'
+              ? { materialization: 'table' }
+              : {}),
           },
           relation: {
             originalFilePath: `models/${options.layer}/${options.id.split('.').at(-1)}.sql`,
@@ -242,6 +248,26 @@ describe('dbt governance signals', () => {
         diagnosticCodes: expect.arrayContaining(['DBT_OWNER_MISSING']),
       },
     });
+  });
+
+  it('does not emit documentation signals for dbt test nodes', () => {
+    const workspace = createWorkspace([
+      createProject({
+        id: 'test.analytics.not_null_public_orders_order_id',
+        resourceType: 'test',
+        layer: 'marts',
+        domain: 'finance',
+        publicInterface: true,
+        description: false,
+      }),
+    ]);
+
+    const codes = buildDbtGovernanceSignals(createSignalInput(workspace)).map(
+      (signal) => String(signal.metadata?.code ?? ''),
+    );
+
+    expect(codes).not.toContain('DBT_DESCRIPTION_MISSING');
+    expect(codes).not.toContain('DBT_PUBLIC_MODEL_UNDOCUMENTED_CANDIDATE');
   });
 
   it('emits dependency-level dbt layering, domain, and ownership signals', () => {

--- a/packages/governance/extension-dbt/src/signals.ts
+++ b/packages/governance/extension-dbt/src/signals.ts
@@ -336,6 +336,10 @@ function appendDocumentationSignals(
   resolution: DbtGovernanceMetadataResolution,
   createdAt: string,
 ): void {
+  if (isDbtTestResolution(resolution)) {
+    return;
+  }
+
   const documentationPresent = isResolvedTrue(resolution.documentationPresent);
   const documentationMissing = isMissingBooleanResolution(
     resolution.documentationPresent,
@@ -1165,4 +1169,13 @@ function asString(value: unknown): string | undefined {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+function isDbtTestResolution(
+  resolution: DbtGovernanceMetadataResolution,
+): boolean {
+  return (
+    resolution.dbtUniqueId?.startsWith('test.') === true ||
+    resolution.governanceNodeId.startsWith('test.')
+  );
 }


### PR DESCRIPTION
closes #434