### PR TITLE
fix(governance-extension-dbt): Preserve dbt source metadata provenance when resolving inherited source table governance metadata

### DIFF
--- a/packages/governance/adapter-dbt/src/normalize-dbt-artifacts.spec.ts
+++ b/packages/governance/adapter-dbt/src/normalize-dbt-artifacts.spec.ts
@@ -486,10 +486,6 @@ describe('dbt artifact normalization', () => {
     expect(getDbtNodeExpansion(node)?.data.resource).toMatchObject({
       meta: {
         lineage: 'external',
-        owner: 'raw-data-team',
-        domain: 'finance',
-        layer: 'raw',
-        criticality: 'high',
       },
       sourceMeta: {
         governance: {
@@ -497,6 +493,18 @@ describe('dbt artifact normalization', () => {
           domain: 'finance',
           layer: 'raw',
           criticality: 'high',
+        },
+      },
+      resolvedGovernanceMeta: {
+        owner: 'raw-data-team',
+        domain: 'finance',
+        layer: 'raw',
+        criticality: 'high',
+        provenance: {
+          owner: 'source.meta.governance',
+          domain: 'source.meta.governance',
+          layer: 'source.meta.governance',
+          criticality: 'source.meta.governance',
         },
       },
     });
@@ -544,10 +552,7 @@ describe('dbt artifact normalization', () => {
           layer: 'table-layer',
           criticality: 'critical',
         },
-        owner: 'table-governance-owner',
-        domain: 'table-domain',
-        layer: 'table-layer',
-        criticality: 'critical',
+        owner: 'table-meta-owner',
       },
       sourceMeta: {
         governance: {
@@ -557,6 +562,18 @@ describe('dbt artifact normalization', () => {
           criticality: 'high',
         },
         owner: 'source-meta-owner',
+      },
+      resolvedGovernanceMeta: {
+        owner: 'table-governance-owner',
+        domain: 'table-domain',
+        layer: 'table-layer',
+        criticality: 'critical',
+        provenance: {
+          owner: 'table.meta.governance',
+          domain: 'table.meta.governance',
+          layer: 'table.meta.governance',
+          criticality: 'table.meta.governance',
+        },
       },
     });
   });
@@ -589,10 +606,6 @@ describe('dbt artifact normalization', () => {
     expect(getDbtNodeExpansion(node)?.data.resource).toMatchObject({
       meta: {
         lineage: 'external',
-        owner: 'source-meta-owner',
-        domain: 'source-meta-domain',
-        layer: 'source-meta-layer',
-        criticality: 'medium',
       },
       sourceMeta: {
         owner: 'source-meta-owner',
@@ -600,7 +613,118 @@ describe('dbt artifact normalization', () => {
         layer: 'source-meta-layer',
         criticality: 'medium',
       },
+      resolvedGovernanceMeta: {
+        owner: 'source-meta-owner',
+        domain: 'source-meta-domain',
+        layer: 'source-meta-layer',
+        criticality: 'medium',
+        provenance: {
+          owner: 'source.meta',
+          domain: 'source.meta',
+          layer: 'source.meta',
+          criticality: 'source.meta',
+        },
+      },
     });
+  });
+
+  it('prefers governance namespaced source table metadata over plain meta at the same level', () => {
+    const node = normalizeSyntheticNode({
+      resource_type: 'source',
+      unique_id:
+        'source.valid_project.raw.synthetic_source_governance_namespace_case',
+      name: 'synthetic_source_governance_namespace_case',
+      source_name: 'raw',
+      meta: {
+        governance: {
+          owner: 'table-governance-owner',
+          domain: 'table-governance-domain',
+          layer: 'table-governance-layer',
+          criticality: 'critical',
+        },
+        owner: 'table-meta-owner',
+        domain: 'table-meta-domain',
+        layer: 'table-meta-layer',
+        criticality: 'high',
+      },
+      source_meta: {
+        governance: {
+          owner: 'source-governance-owner',
+        },
+        owner: 'source-meta-owner',
+      },
+    });
+
+    expect(node.ownership).toEqual({
+      team: 'table-governance-owner',
+      source: 'dbt-manifest',
+    });
+    expect(node.classification).toMatchObject({
+      domain: 'table-governance-domain',
+      layer: 'table-governance-layer',
+    });
+    expect(getDbtNodeExpansion(node)?.data.resource).toMatchObject({
+      meta: {
+        governance: {
+          owner: 'table-governance-owner',
+          domain: 'table-governance-domain',
+          layer: 'table-governance-layer',
+          criticality: 'critical',
+        },
+        owner: 'table-meta-owner',
+        domain: 'table-meta-domain',
+        layer: 'table-meta-layer',
+        criticality: 'high',
+      },
+      sourceMeta: {
+        governance: {
+          owner: 'source-governance-owner',
+        },
+        owner: 'source-meta-owner',
+      },
+      resolvedGovernanceMeta: {
+        owner: 'table-governance-owner',
+        domain: 'table-governance-domain',
+        layer: 'table-governance-layer',
+        criticality: 'critical',
+        provenance: {
+          owner: 'table.meta.governance',
+          domain: 'table.meta.governance',
+          layer: 'table.meta.governance',
+          criticality: 'table.meta.governance',
+        },
+      },
+    });
+  });
+
+  it('keeps dbt source metadata missing when no table or source governance fields are present', () => {
+    const node = normalizeSyntheticNode({
+      resource_type: 'source',
+      unique_id:
+        'source.valid_project.raw.synthetic_source_missing_metadata_case',
+      name: 'synthetic_source_missing_metadata_case',
+      source_name: 'raw',
+      meta: {
+        lineage: 'external',
+      },
+      source_meta: {
+        freshness: 'daily',
+      },
+    });
+
+    expect(node.ownership).toBeUndefined();
+    expect(node.classification).toBeUndefined();
+    expect(getDbtNodeExpansion(node)?.data.resource).toMatchObject({
+      meta: {
+        lineage: 'external',
+      },
+      sourceMeta: {
+        freshness: 'daily',
+      },
+    });
+    expect(getDbtNodeExpansion(node)?.data.resource).not.toHaveProperty(
+      'resolvedGovernanceMeta',
+    );
   });
 
   it('keeps relation ids deterministic for equivalent manifest input orderings', () => {

--- a/packages/governance/adapter-dbt/src/normalize-dbt-artifacts.ts
+++ b/packages/governance/adapter-dbt/src/normalize-dbt-artifacts.ts
@@ -90,8 +90,26 @@ interface RelationMappingResult {
 interface DbtSourceMetadataView {
   tableMeta: ResourceRecord;
   sourceMeta?: ResourceRecord;
-  normalizedMeta: ResourceRecord;
+  resolvedGovernanceMeta?: DbtResolvedSourceGovernanceMeta;
 }
+
+type DbtSourceGovernanceField = 'owner' | 'domain' | 'layer' | 'criticality';
+
+type DbtSourceGovernanceProvenance =
+  | 'table.meta.governance'
+  | 'table.meta'
+  | 'source.meta.governance'
+  | 'source.meta';
+
+type DbtSourceGovernanceProvenanceMap = Partial<
+  Record<DbtSourceGovernanceField, DbtSourceGovernanceProvenance>
+>;
+
+type DbtResolvedSourceGovernanceMeta = Partial<
+  Record<DbtSourceGovernanceField, string>
+> & {
+  provenance?: DbtSourceGovernanceProvenanceMap;
+};
 
 export function normalizeDbtArtifacts(
   projectContext: DbtProjectContext,
@@ -594,13 +612,15 @@ function normalizeDbtManifestResource(
   const fqn = readStringArray(record.fqn);
   const fullyQualifiedName = fqn.length > 0 ? fqn.join('.') : undefined;
   const classification = deriveClassification(
-    sourceMetadataView.normalizedMeta,
+    sourceMetadataView.tableMeta,
+    sourceMetadataView.resolvedGovernanceMeta,
     resourceTags,
   );
   const ownership = normalizeOwnership(
     record,
     group,
-    sourceMetadataView.normalizedMeta,
+    sourceMetadataView.tableMeta,
+    sourceMetadataView.resolvedGovernanceMeta,
   );
   const dbtMetadata = buildDbtResourceMetadata(record, {
     uniqueId,
@@ -690,9 +710,15 @@ function buildDbtResourceMetadata(
     },
     resource: {
       tags: readStringArray(resource.tags),
-      meta: options.sourceMetadataView.normalizedMeta,
+      meta: options.sourceMetadataView.tableMeta,
       ...(options.sourceMetadataView.sourceMeta
         ? { sourceMeta: options.sourceMetadataView.sourceMeta }
+        : {}),
+      ...(options.sourceMetadataView.resolvedGovernanceMeta
+        ? {
+            resolvedGovernanceMeta:
+              options.sourceMetadataView.resolvedGovernanceMeta,
+          }
         : {}),
       ...(readMaterialization(resource)
         ? { materialization: readMaterialization(resource) }
@@ -790,13 +816,18 @@ function collectIncompleteMetadataFields(
 
 function deriveClassification(
   meta: ResourceRecord,
+  resolvedGovernanceMeta: DbtResolvedSourceGovernanceMeta | undefined,
   tags: readonly string[],
 ): GovernanceClassificationInput | undefined {
   const governanceMeta = asRecord(meta.governance);
   const scope =
     readOptionalString(governanceMeta?.scope ?? meta.scope) ?? inferScope(tags);
-  const domain = readOptionalString(governanceMeta?.domain ?? meta.domain);
-  const layer = readOptionalString(governanceMeta?.layer ?? meta.layer);
+  const domain = readOptionalString(
+    resolvedGovernanceMeta?.domain ?? governanceMeta?.domain ?? meta.domain,
+  );
+  const layer = readOptionalString(
+    resolvedGovernanceMeta?.layer ?? governanceMeta?.layer ?? meta.layer,
+  );
 
   if (!domain && !layer && !scope && tags.length === 0) {
     return undefined;
@@ -819,51 +850,73 @@ function readDbtSourceMetadataView(
   if (resourceType !== 'source') {
     return {
       tableMeta,
-      normalizedMeta: tableMeta,
     };
   }
 
   const sourceMeta = asRecord(resource.source_meta);
-  if (!sourceMeta) {
-    return {
-      tableMeta,
-      normalizedMeta: tableMeta,
-    };
-  }
+  const resolvedGovernanceMeta = resolveDbtSourceGovernanceMeta(
+    tableMeta,
+    sourceMeta,
+  );
 
   return {
     tableMeta,
-    sourceMeta,
-    normalizedMeta: normalizeDbtSourceTableMeta(tableMeta, sourceMeta),
+    ...(sourceMeta ? { sourceMeta } : {}),
+    ...(resolvedGovernanceMeta ? { resolvedGovernanceMeta } : {}),
   };
 }
 
-function normalizeDbtSourceTableMeta(
+function resolveDbtSourceGovernanceMeta(
   tableMeta: ResourceRecord,
-  sourceMeta: ResourceRecord,
-): ResourceRecord {
-  const normalizedMeta: ResourceRecord = {
-    ...tableMeta,
-  };
+  sourceMeta: ResourceRecord | undefined,
+): DbtResolvedSourceGovernanceMeta | undefined {
+  const resolvedGovernanceMeta: DbtResolvedSourceGovernanceMeta = {};
+  const provenance: DbtSourceGovernanceProvenanceMap = {};
 
-  applyNormalizedSourceField(normalizedMeta, tableMeta, sourceMeta, 'owner');
-  applyNormalizedSourceField(normalizedMeta, tableMeta, sourceMeta, 'domain');
-  applyNormalizedSourceField(normalizedMeta, tableMeta, sourceMeta, 'layer');
-  applyNormalizedSourceField(
-    normalizedMeta,
+  applyResolvedSourceField(
+    resolvedGovernanceMeta,
+    provenance,
+    tableMeta,
+    sourceMeta,
+    'owner',
+  );
+  applyResolvedSourceField(
+    resolvedGovernanceMeta,
+    provenance,
+    tableMeta,
+    sourceMeta,
+    'domain',
+  );
+  applyResolvedSourceField(
+    resolvedGovernanceMeta,
+    provenance,
+    tableMeta,
+    sourceMeta,
+    'layer',
+  );
+  applyResolvedSourceField(
+    resolvedGovernanceMeta,
+    provenance,
     tableMeta,
     sourceMeta,
     'criticality',
   );
 
-  return normalizedMeta;
+  if (Object.keys(provenance).length > 0) {
+    resolvedGovernanceMeta.provenance = provenance;
+  }
+
+  return Object.keys(resolvedGovernanceMeta).length > 0
+    ? resolvedGovernanceMeta
+    : undefined;
 }
 
-function applyNormalizedSourceField(
-  normalizedMeta: ResourceRecord,
+function applyResolvedSourceField(
+  resolvedGovernanceMeta: DbtResolvedSourceGovernanceMeta,
+  provenance: DbtSourceGovernanceProvenanceMap,
   tableMeta: ResourceRecord,
-  sourceMeta: ResourceRecord,
-  field: 'owner' | 'domain' | 'layer' | 'criticality',
+  sourceMeta: ResourceRecord | undefined,
+  field: DbtSourceGovernanceField,
 ): void {
   const resolvedValue = resolveSourceMetadataField(
     tableMeta,
@@ -871,25 +924,57 @@ function applyNormalizedSourceField(
     field,
   );
 
-  if (resolvedValue !== undefined) {
-    normalizedMeta[field] = resolvedValue;
+  if (resolvedValue) {
+    resolvedGovernanceMeta[field] = resolvedValue.value;
+    provenance[field] = resolvedValue.provenance;
   }
 }
 
 function resolveSourceMetadataField(
   tableMeta: ResourceRecord,
-  sourceMeta: ResourceRecord,
-  field: 'owner' | 'domain' | 'layer' | 'criticality',
-): string | undefined {
+  sourceMeta: ResourceRecord | undefined,
+  field: DbtSourceGovernanceField,
+):
+  | {
+      value: string;
+      provenance: DbtSourceGovernanceProvenance;
+    }
+  | undefined {
   const tableGovernanceMeta = asRecord(tableMeta.governance);
-  const sourceGovernanceMeta = asRecord(sourceMeta.governance);
+  const sourceGovernanceMeta = asRecord(sourceMeta?.governance);
+  const candidates: Array<{
+    value: unknown;
+    provenance: DbtSourceGovernanceProvenance;
+  }> = [
+    {
+      value: tableGovernanceMeta?.[field],
+      provenance: 'table.meta.governance',
+    },
+    {
+      value: tableMeta[field],
+      provenance: 'table.meta',
+    },
+    {
+      value: sourceGovernanceMeta?.[field],
+      provenance: 'source.meta.governance',
+    },
+    {
+      value: sourceMeta?.[field],
+      provenance: 'source.meta',
+    },
+  ];
 
-  return readOptionalString(
-    tableGovernanceMeta?.[field] ??
-      tableMeta[field] ??
-      sourceGovernanceMeta?.[field] ??
-      sourceMeta[field],
-  );
+  for (const candidate of candidates) {
+    const value = readOptionalString(candidate.value);
+    if (value) {
+      return {
+        value,
+        provenance: candidate.provenance,
+      };
+    }
+  }
+
+  return undefined;
 }
 
 function inferScope(tags: readonly string[]): string | undefined {
@@ -901,6 +986,7 @@ function normalizeOwnership(
   resource: ResourceRecord,
   group?: string,
   meta: ResourceRecord = {},
+  resolvedGovernanceMeta?: DbtResolvedSourceGovernanceMeta,
 ): GovernanceOwnershipInput | undefined {
   const config = asRecord(resource.config);
   const configMeta = asRecord(config?.meta);
@@ -912,6 +998,7 @@ function normalizeOwnership(
     normalizeOwner(group) ??
     normalizeOwner(configGovernanceMeta?.owner) ??
     normalizeOwner(configMeta?.owner) ??
+    normalizeOwner(resolvedGovernanceMeta?.owner) ??
     normalizeOwner(governanceMeta?.owner) ??
     normalizeOwner(meta.owner)
   );

--- a/packages/governance/extension-dbt/src/resolvers.spec.ts
+++ b/packages/governance/extension-dbt/src/resolvers.spec.ts
@@ -343,15 +343,9 @@ describe('dbt governance metadata resolvers', () => {
     });
   });
 
-  it('interprets normalized source metadata using the dbt source precedence strategy', () => {
+  it('interprets resolved dbt source governance metadata without flattening raw source facts into resource.meta', () => {
     const input = createInput({
       id: 'source.valid_project.raw.orders',
-      domain: 'source-table-domain',
-      layer: 'source-table-layer',
-      ownership: {
-        team: 'source-table-owner',
-        source: 'dbt-manifest',
-      },
       metadata: {
         dbt: {
           identity: {
@@ -361,10 +355,6 @@ describe('dbt governance metadata resolvers', () => {
           resource: {
             meta: {
               lineage: 'external',
-              owner: 'source-table-owner',
-              domain: 'source-table-domain',
-              layer: 'source-table-layer',
-              criticality: 'high',
             },
             sourceMeta: {
               governance: {
@@ -372,6 +362,18 @@ describe('dbt governance metadata resolvers', () => {
                 domain: 'finance',
                 layer: 'raw',
                 criticality: 'medium',
+              },
+            },
+            resolvedGovernanceMeta: {
+              owner: 'source-table-owner',
+              domain: 'source-table-domain',
+              layer: 'source-table-layer',
+              criticality: 'high',
+              provenance: {
+                owner: 'table.meta',
+                domain: 'table.meta',
+                layer: 'table.meta',
+                criticality: 'table.meta',
               },
             },
           },
@@ -387,21 +389,86 @@ describe('dbt governance metadata resolvers', () => {
     expect(resolveDbtOwner(input)).toMatchObject({
       status: 'resolved',
       value: 'source-table-owner',
-      sourcePaths: ['node.ownership.team'],
+      sourcePaths: ['metadata.dbt.resource.resolvedGovernanceMeta.owner'],
     });
     expect(resolveDbtDomain(input)).toMatchObject({
       status: 'resolved',
       value: 'source-table-domain',
-      sourcePaths: expect.arrayContaining(['node.classification.domain']),
+      sourcePaths: ['metadata.dbt.resource.resolvedGovernanceMeta.domain'],
     });
     expect(resolveDbtLayer(input)).toMatchObject({
       status: 'resolved',
       value: 'source-table-layer',
-      sourcePaths: expect.arrayContaining(['node.classification.layer']),
+      sourcePaths: ['metadata.dbt.resource.resolvedGovernanceMeta.layer'],
     });
     expect(resolveDbtCriticality(input)).toMatchObject({
       status: 'resolved',
       value: 'high',
+      sourcePaths: ['metadata.dbt.resource.resolvedGovernanceMeta.criticality'],
+    });
+  });
+
+  it('falls back to legacy flattened dbt source metadata when resolved governance metadata is absent', () => {
+    const input = createInput({
+      id: 'source.valid_project.raw.orders',
+      metadata: {
+        dbt: {
+          identity: {
+            uniqueId: 'source.valid_project.raw.orders',
+            resourceType: 'source',
+          },
+          resource: {
+            meta: {
+              owner: 'legacy-source-owner',
+              domain: 'legacy-source-domain',
+              layer: 'legacy-source-layer',
+              criticality: 'legacy-criticality',
+            },
+            sourceMeta: {
+              governance: {
+                owner: 'raw-data-team',
+              },
+            },
+          },
+          relation: {
+            originalFilePath: 'models/raw/raw.yml',
+          },
+          validation: {},
+          documentation: {},
+        },
+      },
+    });
+
+    expect(resolveDbtOwner(input)).toMatchObject({
+      status: 'resolved',
+      value: 'legacy-source-owner',
+      sourcePaths: ['metadata.dbt.resource.meta.owner'],
+    });
+    expect(
+      resolveDbtDomain(input, {
+        domain: {
+          fromPath: false,
+        },
+      }),
+    ).toMatchObject({
+      status: 'resolved',
+      value: 'legacy-source-domain',
+      sourcePaths: ['metadata.dbt.resource.meta.domain'],
+    });
+    expect(
+      resolveDbtLayer(input, {
+        layer: {
+          fromPath: false,
+        },
+      }),
+    ).toMatchObject({
+      status: 'resolved',
+      value: 'legacy-source-layer',
+      sourcePaths: ['metadata.dbt.resource.meta.layer'],
+    });
+    expect(resolveDbtCriticality(input)).toMatchObject({
+      status: 'resolved',
+      value: 'legacy-criticality',
       sourcePaths: ['metadata.dbt.resource.meta.criticality'],
     });
   });

--- a/packages/governance/extension-dbt/src/resolvers.ts
+++ b/packages/governance/extension-dbt/src/resolvers.ts
@@ -127,6 +127,12 @@ export function resolveDbtLayer(
     input.layer,
     'node.classification.layer',
   );
+  collectResolvedGovernanceStringCandidate(
+    input,
+    explicitValid,
+    explicitInvalid,
+    'layer',
+  );
   collectStringCandidate(
     explicitValid,
     explicitInvalid,
@@ -188,6 +194,12 @@ export function resolveDbtDomain(
     explicitInvalid,
     input.domain,
     'node.classification.domain',
+  );
+  collectResolvedGovernanceStringCandidate(
+    input,
+    explicitValid,
+    explicitInvalid,
+    'domain',
   );
   collectStringCandidate(
     explicitValid,
@@ -254,6 +266,12 @@ export function resolveDbtOwner(
     readPathValue(input.metadata, ['dbt', 'resource', 'group']),
     'metadata.dbt.resource.group',
   );
+  collectResolvedGovernanceOwnerCandidate(
+    input,
+    metadataValid,
+    metadataInvalid,
+    'owner',
+  );
   collectStringCandidate(
     metadataValid,
     metadataInvalid,
@@ -274,6 +292,12 @@ export function resolveDbtCriticality(
   const valid: ResolutionCandidate<string>[] = [];
   const invalid: InvalidResolutionCandidate[] = [];
 
+  collectResolvedGovernanceStringCandidate(
+    input,
+    valid,
+    invalid,
+    'criticality',
+  );
   collectStringCandidate(
     valid,
     invalid,
@@ -724,6 +748,44 @@ function collectOwnerCandidate(
   });
 }
 
+function collectResolvedGovernanceStringCandidate(
+  input: DbtGovernanceMetadataResolverInput,
+  valid: ResolutionCandidate<string>[],
+  invalid: InvalidResolutionCandidate[],
+  field: 'domain' | 'layer' | 'criticality',
+): void {
+  const resolvedField = readResolvedGovernanceField(input, field);
+  if (!resolvedField) {
+    return;
+  }
+
+  collectStringCandidate(
+    valid,
+    invalid,
+    resolvedField.value,
+    resolvedField.sourcePath,
+  );
+}
+
+function collectResolvedGovernanceOwnerCandidate(
+  input: DbtGovernanceMetadataResolverInput,
+  valid: ResolutionCandidate<string>[],
+  invalid: InvalidResolutionCandidate[],
+  field: 'owner',
+): void {
+  const resolvedField = readResolvedGovernanceField(input, field);
+  if (!resolvedField) {
+    return;
+  }
+
+  collectOwnerCandidate(
+    valid,
+    invalid,
+    resolvedField.value,
+    resolvedField.sourcePath,
+  );
+}
+
 function readOwnershipTeam(
   ownership: DbtGovernanceMetadataResolverInput['ownership'],
 ): unknown {
@@ -732,6 +794,29 @@ function readOwnershipTeam(
   }
 
   return ownership.team;
+}
+
+function readResolvedGovernanceField(
+  input: DbtGovernanceMetadataResolverInput,
+  field: 'owner' | 'domain' | 'layer' | 'criticality',
+): { value: unknown; sourcePath: string } | undefined {
+  // Keep a compatibility bridge for older adapter payloads by checking
+  // resource.meta.* after this helper returns undefined.
+  const resolvedField = readPathValue(input.metadata, [
+    'dbt',
+    'resource',
+    'resolvedGovernanceMeta',
+    field,
+  ]);
+
+  if (resolvedField !== undefined) {
+    return {
+      value: resolvedField,
+      sourcePath: `metadata.dbt.resource.resolvedGovernanceMeta.${field}`,
+    };
+  }
+
+  return undefined;
 }
 
 function readPathValue(


### PR DESCRIPTION
close #442
