### PR TITLE
fix(governance-extension-dbt): dbt test-coverage signals apply to the wrong dbt node types and miss inferred coverage from manifest test nodes

### DIFF
--- a/packages/governance/extension-dbt/src/applicability.ts
+++ b/packages/governance/extension-dbt/src/applicability.ts
@@ -12,6 +12,7 @@ const DBT_GOVERNED_ASSET_RESOURCE_TYPES = new Set([
   'semantic_model',
   'saved_query',
 ]);
+const DBT_TEST_COVERAGE_RESOURCE_TYPES = new Set(['model', 'source']);
 
 export function getDbtResolutionResourceType(
   resolution: DbtGovernanceMetadataResolution,
@@ -46,6 +47,23 @@ export function isDbtGovernedAssetResolution(
   }
 
   return DBT_GOVERNED_ASSET_RESOURCE_TYPES.has(resourceType);
+}
+
+export function isDbtTestCoverageResourceType(
+  resourceType: string | undefined,
+): boolean {
+  return (
+    resourceType !== undefined &&
+    DBT_TEST_COVERAGE_RESOURCE_TYPES.has(resourceType)
+  );
+}
+
+export function isDbtTestCoverageTarget(
+  resolution: DbtGovernanceMetadataResolution,
+): boolean {
+  return isDbtTestCoverageResourceType(
+    getDbtResolutionResourceType(resolution),
+  );
 }
 
 export function isDbtDocumentationTarget(

--- a/packages/governance/extension-dbt/src/dbt-graph.ts
+++ b/packages/governance/extension-dbt/src/dbt-graph.ts
@@ -11,6 +11,7 @@ import type {
   DbtGovernanceNodeExpansionData,
   DbtGovernanceRelationExpansionData,
 } from './contracts.js';
+import { isDbtTestCoverageResourceType } from './applicability.js';
 import { getDbtGovernanceModelExpansion } from './contracts.js';
 import type { DbtGovernanceMetadataResolverInput } from './resolvers.js';
 
@@ -24,7 +25,6 @@ const DBT_RELATION_KINDS = new Set([
 ]);
 
 const DBT_DEPENDENCY_RELATION_KINDS = new Set(['dependency', 'lineage']);
-const TEST_COVERAGE_RESOURCE_TYPES = new Set(['model', 'source']);
 
 export function getDbtNodes(workspace: GovernanceWorkspace): GovernanceNode[] {
   return workspace.nodes.filter((node) => isDbtNode(node));
@@ -330,10 +330,7 @@ function isDbtTestNode(node: GovernanceNode): boolean {
 }
 
 function isDbtTestCoverageTarget(node: GovernanceNode): boolean {
-  const resourceType = getDbtResourceType(node);
-  return (
-    resourceType !== undefined && TEST_COVERAGE_RESOURCE_TYPES.has(resourceType)
-  );
+  return isDbtTestCoverageResourceType(getDbtResourceType(node));
 }
 
 function getDbtResourceType(node: GovernanceNode): string | undefined {
@@ -355,6 +352,10 @@ function getDbtResourceType(node: GovernanceNode): string | undefined {
   if (node.id.startsWith('snapshot.')) return 'snapshot';
   if (node.id.startsWith('exposure.')) return 'exposure';
   if (node.id.startsWith('test.')) return 'test';
+  if (node.id.startsWith('metric.')) return 'metric';
+  if (node.id.startsWith('semantic_model.')) return 'semantic_model';
+  if (node.id.startsWith('saved_query.')) return 'saved_query';
+  if (node.id.startsWith('dbt.project.')) return 'project';
 
   return undefined;
 }

--- a/packages/governance/extension-dbt/src/index.ts
+++ b/packages/governance/extension-dbt/src/index.ts
@@ -52,6 +52,8 @@ export {
   isDbtEvidenceResource,
   isDbtGovernedAssetResolution,
   isDbtPublicModelDocumentationTarget,
+  isDbtTestCoverageResourceType,
+  isDbtTestCoverageTarget,
 } from './applicability.js';
 export {
   DBT_GOVERNANCE_DIAGNOSTIC_CODES,

--- a/packages/governance/extension-dbt/src/recommendations.spec.ts
+++ b/packages/governance/extension-dbt/src/recommendations.spec.ts
@@ -110,6 +110,7 @@ describe('dbt governance recommendations', () => {
 
   function createProject(options: {
     id: string;
+    resourceType?: 'model' | 'source' | 'seed' | 'test' | 'project';
     layer?: string;
     domain?: string;
     owner?: string;
@@ -141,7 +142,8 @@ describe('dbt governance recommendations', () => {
         dbt: {
           identity: {
             uniqueId: options.id,
-            resourceType: 'model',
+            resourceType:
+              options.resourceType ?? inferResourceTypeFromId(options.id),
           },
           resource: {
             tags: options.publicInterface ? ['public'] : [],
@@ -162,7 +164,10 @@ describe('dbt governance recommendations', () => {
                   },
                 }
               : {}),
-            materialization: 'table',
+            ...((options.resourceType ??
+              inferResourceTypeFromId(options.id)) !== 'test'
+              ? { materialization: 'table' }
+              : {}),
           },
           relation: {
             originalFilePath: `models/${options.layer ?? 'unknown'}/${leafName}.sql`,
@@ -179,6 +184,28 @@ describe('dbt governance recommendations', () => {
         },
       },
     };
+  }
+
+  function inferResourceTypeFromId(
+    id: string,
+  ): 'model' | 'source' | 'seed' | 'test' | 'project' {
+    if (id.startsWith('source.')) {
+      return 'source';
+    }
+
+    if (id.startsWith('seed.')) {
+      return 'seed';
+    }
+
+    if (id.startsWith('test.')) {
+      return 'test';
+    }
+
+    if (id.startsWith('dbt.project.')) {
+      return 'project';
+    }
+
+    return 'model';
   }
 
   function createResolution(project: TestWorkspaceProject) {
@@ -421,6 +448,77 @@ describe('dbt governance recommendations', () => {
         code: 'ADD_TESTS',
       }),
     });
+  });
+
+  it('does not emit ADD_TESTS for dbt project, test, or seed resources', () => {
+    const projectNode = createProject({
+      id: 'dbt.project.analytics',
+      resourceType: 'project',
+      layer: 'marts',
+      domain: 'finance',
+    });
+    const testNode = createProject({
+      id: 'test.analytics.not_null_orders_order_id',
+      resourceType: 'test',
+      layer: 'marts',
+      domain: 'finance',
+    });
+    const seedNode = createProject({
+      id: 'seed.analytics.calendar',
+      resourceType: 'seed',
+      layer: 'staging',
+      domain: 'finance',
+    });
+    const workspace = createWorkspace([projectNode, testNode, seedNode]);
+
+    const recommendations = buildDbtGovernanceRecommendations(
+      createRecommendationInput(workspace, {
+        metadataResolutions: [
+          createResolution(projectNode),
+          createResolution(testNode),
+          createResolution(seedNode),
+        ],
+        signals: [
+          createSignal({
+            id: 'signal-project-tests',
+            code: 'DBT_TESTS_MISSING',
+            nodeId: projectNode.id,
+            dbtUniqueId: projectNode.id,
+          }),
+          createSignal({
+            id: 'signal-test-tests',
+            code: 'DBT_TESTS_MISSING',
+            nodeId: testNode.id,
+            dbtUniqueId: testNode.id,
+          }),
+          createSignal({
+            id: 'signal-seed-tests',
+            code: 'DBT_TESTS_MISSING',
+            nodeId: seedNode.id,
+            dbtUniqueId: seedNode.id,
+          }),
+        ],
+        violations: [
+          createViolation({
+            id: 'violation-project-tests',
+            ruleId: 'dbt/critical-models-require-tests',
+            nodeId: projectNode.id,
+          }),
+          createViolation({
+            id: 'violation-test-tests',
+            ruleId: 'dbt/critical-models-require-tests',
+            nodeId: testNode.id,
+          }),
+          createViolation({
+            id: 'violation-seed-tests',
+            ruleId: 'dbt/critical-models-require-tests',
+            nodeId: seedNode.id,
+          }),
+        ],
+      }),
+    );
+
+    expect(findRecommendation(recommendations, 'ADD_TESTS')).toBeUndefined();
   });
 
   it('emits ENABLE_CONTRACT for governed models without contracts', () => {

--- a/packages/governance/extension-dbt/src/recommendations.ts
+++ b/packages/governance/extension-dbt/src/recommendations.ts
@@ -18,6 +18,7 @@ import {
   normalizeIds,
   toResolverInput,
 } from './dbt-graph.js';
+import { isDbtTestCoverageTarget } from './applicability.js';
 import { buildDbtGovernanceDiagnostics } from './diagnostics.js';
 import { buildDbtGovernanceMetrics } from './metrics.js';
 import { evaluateDbtArchitectureViolations } from './rule-pack.js';
@@ -390,6 +391,11 @@ function buildAddTestsRecommendations(
       continue;
     }
 
+    const resolution = resolutionByNodeId.get(signal.nodeId);
+    if (!resolution || !isDbtTestCoverageTarget(resolution)) {
+      continue;
+    }
+
     upsertDraft(
       byNodeId,
       signal.nodeId,
@@ -409,8 +415,7 @@ function buildAddTestsRecommendations(
         category: 'documentation',
         governanceNodeId: signal.nodeId,
         dbtUniqueId:
-          asString(signal.metadata?.dbtUniqueId) ??
-          resolutionByNodeId.get(signal.nodeId)?.dbtUniqueId,
+          asString(signal.metadata?.dbtUniqueId) ?? resolution.dbtUniqueId,
         signal,
       }),
     );
@@ -423,6 +428,11 @@ function buildAddTestsRecommendations(
 
     const nodeId = readViolationNodeId(violation);
     if (!nodeId) {
+      continue;
+    }
+
+    const resolution = resolutionByNodeId.get(nodeId);
+    if (!resolution || !isDbtTestCoverageTarget(resolution)) {
       continue;
     }
 
@@ -439,7 +449,7 @@ function buildAddTestsRecommendations(
           'Add appropriate dbt tests for the critical model before treating it as governed output.',
         category: 'documentation',
         governanceNodeId: nodeId,
-        dbtUniqueId: resolutionByNodeId.get(nodeId)?.dbtUniqueId,
+        dbtUniqueId: resolution.dbtUniqueId,
         violation,
       }),
     );

--- a/packages/governance/extension-dbt/src/rule-pack.spec.ts
+++ b/packages/governance/extension-dbt/src/rule-pack.spec.ts
@@ -15,6 +15,7 @@ import {
   getDbtResolutionResourceType,
   isDbtDocumentationTarget,
   isDbtPublicModelDocumentationTarget,
+  isDbtTestCoverageTarget,
   type DbtGovernanceMetadataResolution,
   type DbtGovernanceRulePackInput,
 } from './index.js';
@@ -111,7 +112,7 @@ describe('dbt architecture basic rule pack', () => {
 
   function createProject(options: {
     id: string;
-    resourceType?: 'model' | 'source' | 'test';
+    resourceType?: 'model' | 'source' | 'seed' | 'test' | 'project';
     layer?: string;
     domain?: string;
     owner?: string;
@@ -199,13 +200,23 @@ describe('dbt architecture basic rule pack', () => {
     };
   }
 
-  function inferResourceTypeFromId(id: string): 'model' | 'source' | 'test' {
+  function inferResourceTypeFromId(
+    id: string,
+  ): 'model' | 'source' | 'seed' | 'test' | 'project' {
     if (id.startsWith('source.')) {
       return 'source';
     }
 
+    if (id.startsWith('seed.')) {
+      return 'seed';
+    }
+
     if (id.startsWith('test.')) {
       return 'test';
+    }
+
+    if (id.startsWith('dbt.project.')) {
+      return 'project';
     }
 
     return 'model';
@@ -477,6 +488,54 @@ describe('dbt architecture basic rule pack', () => {
     expect(isDbtDocumentationTarget(legacyTestResolution)).toBe(false);
   });
 
+  it('centralizes dbt test coverage applicability for eligible and ineligible resource types', () => {
+    expect(
+      isDbtTestCoverageTarget(
+        createResolution({
+          governanceNodeId: 'model.valid_project.orders',
+          dbtUniqueId: 'model.valid_project.orders',
+          resourceType: 'model',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isDbtTestCoverageTarget(
+        createResolution({
+          governanceNodeId: 'source.valid_project.raw.orders',
+          dbtUniqueId: 'source.valid_project.raw.orders',
+          resourceType: 'source',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isDbtTestCoverageTarget(
+        createResolution({
+          governanceNodeId: 'dbt.project.valid_project',
+          dbtUniqueId: 'dbt.project.valid_project',
+          resourceType: 'project',
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isDbtTestCoverageTarget(
+        createResolution({
+          governanceNodeId: 'test.valid_project.orders',
+          dbtUniqueId: 'test.valid_project.orders',
+          resourceType: 'test',
+        }),
+      ),
+    ).toBe(false);
+    expect(
+      isDbtTestCoverageTarget(
+        createResolution({
+          governanceNodeId: 'seed.valid_project.calendar',
+          dbtUniqueId: 'seed.valid_project.calendar',
+          resourceType: 'seed',
+        }),
+      ),
+    ).toBe(false);
+  });
+
   it('does not flag documented public models', () => {
     const workspace = createWorkspace([
       createProject({
@@ -729,6 +788,33 @@ describe('dbt architecture basic rule pack', () => {
       evaluateDbtArchitectureViolations(createInput(workspace)).some(
         (violation) =>
           violation.subjectId === 'test.analytics.not_null_orders_order_id',
+      ),
+    ).toBe(false);
+  });
+
+  it('does not flag critical dbt project or seed nodes for missing tests', () => {
+    const workspace = createWorkspace([
+      createProject({
+        id: 'dbt.project.analytics',
+        resourceType: 'project',
+        layer: 'marts',
+        domain: 'finance',
+        criticality: 'critical',
+        tests: false,
+      }),
+      createProject({
+        id: 'seed.analytics.calendar',
+        resourceType: 'seed',
+        layer: 'staging',
+        domain: 'finance',
+        criticality: 'critical',
+        tests: false,
+      }),
+    ]);
+
+    expect(
+      evaluateDbtArchitectureViolations(createInput(workspace)).some(
+        (violation) => violation.ruleId === 'dbt/critical-models-require-tests',
       ),
     ).toBe(false);
   });

--- a/packages/governance/extension-dbt/src/rule-pack.ts
+++ b/packages/governance/extension-dbt/src/rule-pack.ts
@@ -18,7 +18,10 @@ import {
   toRelationReference,
   toResolverInput,
 } from './dbt-graph.js';
-import { isDbtPublicModelDocumentationTarget } from './applicability.js';
+import {
+  isDbtPublicModelDocumentationTarget,
+  isDbtTestCoverageTarget,
+} from './applicability.js';
 import { buildDbtGovernanceDiagnostics } from './diagnostics.js';
 import {
   buildDbtGovernanceSignals,
@@ -518,6 +521,10 @@ function evaluateCriticalModelsRequireTests(
   );
 
   if (!config.enabled) {
+    return [];
+  }
+
+  if (!isDbtTestCoverageTarget(resolution)) {
     return [];
   }
 

--- a/packages/governance/extension-dbt/src/signals.spec.ts
+++ b/packages/governance/extension-dbt/src/signals.spec.ts
@@ -109,7 +109,7 @@ describe('dbt governance signals', () => {
 
   function createProject(options: {
     id: string;
-    resourceType?: 'model' | 'test';
+    resourceType?: 'model' | 'source' | 'seed' | 'test' | 'project';
     layer: string;
     domain: string;
     owner?: string;
@@ -343,6 +343,196 @@ describe('dbt governance signals', () => {
 
     expect(codes).not.toContain('DBT_DESCRIPTION_MISSING');
     expect(codes).not.toContain('DBT_PUBLIC_MODEL_UNDOCUMENTED_CANDIDATE');
+  });
+
+  it('treats generic dbt test nodes linked to a model as test coverage', () => {
+    const modelId = 'model.analytics.orders';
+    const workspace = createWorkspace(
+      [
+        createProject({
+          id: modelId,
+          layer: 'marts',
+          domain: 'finance',
+          tests: false,
+        }),
+        createProject({
+          id: 'test.analytics.not_null_orders_order_id',
+          resourceType: 'test',
+          layer: 'marts',
+          domain: 'finance',
+        }),
+      ],
+      [
+        {
+          source: 'test.analytics.not_null_orders_order_id',
+          target: modelId,
+          type: 'static',
+          metadata: {
+            dbt: {
+              lineage: {
+                relationKind: 'tests',
+              },
+            },
+          },
+        },
+      ],
+    );
+
+    const modelSignalCodes = buildDbtGovernanceSignals(
+      createSignalInput(workspace),
+    )
+      .filter((signal) => signal.nodeId === modelId)
+      .map((signal) => String(signal.metadata?.code ?? ''));
+
+    expect(modelSignalCodes).toContain('DBT_TESTS_PRESENT');
+    expect(modelSignalCodes).not.toContain('DBT_TESTS_MISSING');
+  });
+
+  it('treats dbt source tests linked to a source as test coverage', () => {
+    const sourceId = 'source.analytics.raw.orders';
+    const workspace = createWorkspace(
+      [
+        createProject({
+          id: sourceId,
+          resourceType: 'source',
+          layer: 'staging',
+          domain: 'finance',
+          tests: false,
+        }),
+        createProject({
+          id: 'test.analytics.source_freshness_raw_orders',
+          resourceType: 'test',
+          layer: 'staging',
+          domain: 'finance',
+        }),
+      ],
+      [
+        {
+          source: 'test.analytics.source_freshness_raw_orders',
+          target: sourceId,
+          type: 'static',
+          metadata: {
+            dbt: {
+              lineage: {
+                relationKind: 'tests',
+              },
+            },
+          },
+        },
+      ],
+    );
+
+    const sourceSignalCodes = buildDbtGovernanceSignals(
+      createSignalInput(workspace),
+    )
+      .filter((signal) => signal.nodeId === sourceId)
+      .map((signal) => String(signal.metadata?.code ?? ''));
+
+    expect(sourceSignalCodes).toContain('DBT_TESTS_PRESENT');
+    expect(sourceSignalCodes).not.toContain('DBT_TESTS_MISSING');
+  });
+
+  it('treats relationships dbt test nodes linked to a model as test coverage', () => {
+    const modelId = 'model.analytics.orders';
+    const workspace = createWorkspace(
+      [
+        createProject({
+          id: modelId,
+          layer: 'marts',
+          domain: 'finance',
+          tests: false,
+        }),
+        createProject({
+          id: 'source.analytics.raw.customers',
+          resourceType: 'source',
+          layer: 'staging',
+          domain: 'finance',
+        }),
+        createProject({
+          id: 'test.analytics.relationships_orders_customer_id',
+          resourceType: 'test',
+          layer: 'marts',
+          domain: 'finance',
+        }),
+      ],
+      [
+        {
+          source: 'test.analytics.relationships_orders_customer_id',
+          target: modelId,
+          type: 'static',
+          metadata: {
+            dbt: {
+              lineage: {
+                relationKind: 'tests',
+              },
+            },
+          },
+        },
+        {
+          source: 'test.analytics.relationships_orders_customer_id',
+          target: 'source.analytics.raw.customers',
+          type: 'static',
+          metadata: {
+            dbt: {
+              lineage: {
+                relationKind: 'tests',
+              },
+            },
+          },
+        },
+      ],
+    );
+
+    const modelSignalCodes = buildDbtGovernanceSignals(
+      createSignalInput(workspace),
+    )
+      .filter((signal) => signal.nodeId === modelId)
+      .map((signal) => String(signal.metadata?.code ?? ''));
+
+    expect(modelSignalCodes).toContain('DBT_TESTS_PRESENT');
+    expect(modelSignalCodes).not.toContain('DBT_TESTS_MISSING');
+  });
+
+  it('does not emit test coverage signals for dbt project, test, or seed nodes', () => {
+    const workspace = createWorkspace([
+      createProject({
+        id: 'dbt.project.analytics',
+        resourceType: 'project',
+        layer: 'marts',
+        domain: 'finance',
+        tests: false,
+      }),
+      createProject({
+        id: 'test.analytics.not_null_orders_order_id',
+        resourceType: 'test',
+        layer: 'marts',
+        domain: 'finance',
+        tests: false,
+      }),
+      createProject({
+        id: 'seed.analytics.calendar',
+        resourceType: 'seed',
+        layer: 'staging',
+        domain: 'finance',
+        tests: false,
+      }),
+    ]);
+
+    const testingSignals = buildDbtGovernanceSignals(
+      createSignalInput(workspace),
+    )
+      .filter((signal) =>
+        ['DBT_TESTS_PRESENT', 'DBT_TESTS_MISSING'].includes(
+          String(signal.metadata?.code ?? ''),
+        ),
+      )
+      .map((signal) => signal.nodeId);
+
+    expect(testingSignals).not.toContain('dbt.project.analytics');
+    expect(testingSignals).not.toContain(
+      'test.analytics.not_null_orders_order_id',
+    );
+    expect(testingSignals).not.toContain('seed.analytics.calendar');
   });
 
   it('uses explicit test resource types over model-like ids for documentation signals', () => {

--- a/packages/governance/extension-dbt/src/signals.ts
+++ b/packages/governance/extension-dbt/src/signals.ts
@@ -14,7 +14,10 @@ import type {
   DbtGovernanceSignalProvider,
   DbtGovernanceSignalProviderInput,
 } from './contracts.js';
-import { isDbtDocumentationTarget } from './applicability.js';
+import {
+  isDbtDocumentationTarget,
+  isDbtTestCoverageTarget,
+} from './applicability.js';
 import {
   buildDbtInferredTestNodeIdsByTarget,
   getDbtMetadata,
@@ -417,6 +420,10 @@ function appendTestingSignals(
   resolution: DbtGovernanceMetadataResolution,
   context: DbtSignalContext,
 ): void {
+  if (!isDbtTestCoverageTarget(resolution)) {
+    return;
+  }
+
   const testsPresent = isResolvedTrue(resolution.testsPresent);
   const testsMissing = isMissingBooleanResolution(resolution.testsPresent);
   const criticalityValue =


### PR DESCRIPTION
closes #451