### PR TITLE
fix(governance-extension-dbt): dbt governance still treats project and test evidence nodes as governed assets for ownership checks

### DIFF
--- a/packages/governance/extension-dbt/src/applicability.ts
+++ b/packages/governance/extension-dbt/src/applicability.ts
@@ -1,7 +1,9 @@
 import type { DbtGovernanceMetadataResolution } from './resolvers.js';
 
 const DBT_EVIDENCE_RESOURCE_TYPES = new Set(['test']);
+const DBT_WORKSPACE_CONTEXT_RESOURCE_TYPES = new Set(['project']);
 const DBT_PUBLIC_MODEL_DOCUMENTATION_RESOURCE_TYPES = new Set(['model']);
+const DBT_OWNERSHIP_RESOURCE_TYPES = new Set(['model', 'source']);
 const DBT_GOVERNED_ASSET_RESOURCE_TYPES = new Set([
   'model',
   'seed',
@@ -37,6 +39,16 @@ export function isDbtEvidenceResource(
   );
 }
 
+export function isDbtWorkspaceContextResource(
+  resolution: DbtGovernanceMetadataResolution,
+): boolean {
+  const resourceType = getDbtResolutionResourceType(resolution);
+  return (
+    resourceType !== undefined &&
+    DBT_WORKSPACE_CONTEXT_RESOURCE_TYPES.has(resourceType)
+  );
+}
+
 export function isDbtGovernedAssetResolution(
   resolution: DbtGovernanceMetadataResolution,
 ): boolean {
@@ -47,6 +59,20 @@ export function isDbtGovernedAssetResolution(
   }
 
   return DBT_GOVERNED_ASSET_RESOURCE_TYPES.has(resourceType);
+}
+
+export function isDbtOwnershipResourceType(
+  resourceType: string | undefined,
+): boolean {
+  return (
+    resourceType !== undefined && DBT_OWNERSHIP_RESOURCE_TYPES.has(resourceType)
+  );
+}
+
+export function isDbtOwnershipTarget(
+  resolution: DbtGovernanceMetadataResolution,
+): boolean {
+  return isDbtOwnershipResourceType(getDbtResolutionResourceType(resolution));
 }
 
 export function isDbtTestCoverageResourceType(
@@ -82,6 +108,23 @@ export function isDbtPublicModelDocumentationTarget(
   }
 
   return DBT_PUBLIC_MODEL_DOCUMENTATION_RESOURCE_TYPES.has(resourceType);
+}
+
+export function isDbtContractTarget(
+  resolution: DbtGovernanceMetadataResolution,
+): boolean {
+  const resourceType = getDbtResolutionResourceType(resolution);
+
+  return isDbtGovernedAssetResolution(resolution) && resourceType !== 'source';
+}
+
+export function isDbtDagShapeTarget(
+  resolution: DbtGovernanceMetadataResolution,
+): boolean {
+  return (
+    !isDbtEvidenceResource(resolution) &&
+    !isDbtWorkspaceContextResource(resolution)
+  );
 }
 
 function normalizeResourceType(value: unknown): string | undefined {

--- a/packages/governance/extension-dbt/src/diagnostics.spec.ts
+++ b/packages/governance/extension-dbt/src/diagnostics.spec.ts
@@ -127,6 +127,48 @@ describe('dbt governance diagnostics', () => {
     };
   }
 
+  function createResourceResolution(options: {
+    id: string;
+    resourceType: 'model' | 'source' | 'seed' | 'test' | 'project';
+    layer: string;
+    domain: string;
+    owner?: unknown;
+    originalFilePath: string;
+  }): DbtGovernanceMetadataResolution {
+    return resolveDbtGovernanceMetadata(
+      createResolverInput({
+        id: options.id,
+        metadata: {
+          dbt: {
+            identity: {
+              uniqueId: options.id,
+              resourceType: options.resourceType,
+            },
+            resource: {
+              tags: [],
+              meta: {
+                layer: options.layer,
+                domain: options.domain,
+              },
+              ...(options.owner !== undefined ? { owner: options.owner } : {}),
+              ...(options.resourceType !== 'test'
+                ? {
+                    materialization:
+                      options.resourceType === 'seed' ? 'seed' : 'table',
+                  }
+                : {}),
+            },
+            relation: {
+              originalFilePath: options.originalFilePath,
+            },
+            validation: {},
+            documentation: {},
+          },
+        },
+      }),
+    );
+  }
+
   it('reports unresolved layer/domain/owner metadata and skipped analysis as diagnostics', () => {
     const resolution = resolveDbtGovernanceMetadata(
       createResolverInput({
@@ -233,6 +275,98 @@ describe('dbt governance diagnostics', () => {
         rawValues: ['maybe'],
       },
     });
+  });
+
+  it('only emits owner-missing diagnostics for ownership targets and excludes seed ownership by default', () => {
+    const resolutions = [
+      createResourceResolution({
+        id: 'model.analytics.orders',
+        resourceType: 'model',
+        layer: 'marts',
+        domain: 'finance',
+        originalFilePath: 'models/marts/orders.sql',
+      }),
+      createResourceResolution({
+        id: 'source.analytics.raw.orders',
+        resourceType: 'source',
+        layer: 'staging',
+        domain: 'finance',
+        originalFilePath: 'models/staging/raw_orders.yml',
+      }),
+      createResourceResolution({
+        id: 'test.analytics.not_null_orders_order_id',
+        resourceType: 'test',
+        layer: 'marts',
+        domain: 'finance',
+        originalFilePath: 'tests/not_null_orders_order_id.sql',
+      }),
+      createResourceResolution({
+        id: 'dbt.project.analytics',
+        resourceType: 'project',
+        layer: 'marts',
+        domain: 'finance',
+        originalFilePath: 'dbt_project.yml',
+      }),
+      createResourceResolution({
+        id: 'seed.analytics.calendar',
+        resourceType: 'seed',
+        layer: 'staging',
+        domain: 'finance',
+        originalFilePath: 'seeds/calendar.csv',
+      }),
+    ];
+
+    const ownerMissingNodeIds = buildDbtGovernanceDiagnostics(
+      createProviderInput({
+        metadataResolutions: resolutions,
+      }),
+    )
+      .filter((diagnostic) => diagnostic.code === 'DBT_OWNER_MISSING')
+      .map((diagnostic) => diagnostic.reference?.nodeId);
+
+    expect(ownerMissingNodeIds).toEqual([
+      'model.analytics.orders',
+      'source.analytics.raw.orders',
+    ]);
+  });
+
+  it('only emits owner-invalid diagnostics for ownership targets', () => {
+    const resolutions = [
+      createResourceResolution({
+        id: 'model.analytics.orders',
+        resourceType: 'model',
+        layer: 'marts',
+        domain: 'finance',
+        owner: 42,
+        originalFilePath: 'models/marts/orders.sql',
+      }),
+      createResourceResolution({
+        id: 'test.analytics.not_null_orders_order_id',
+        resourceType: 'test',
+        layer: 'marts',
+        domain: 'finance',
+        owner: 42,
+        originalFilePath: 'tests/not_null_orders_order_id.sql',
+      }),
+      createResourceResolution({
+        id: 'dbt.project.analytics',
+        resourceType: 'project',
+        layer: 'marts',
+        domain: 'finance',
+        owner: 42,
+        originalFilePath: 'dbt_project.yml',
+      }),
+    ];
+
+    const ownerInvalidNodeIds = buildDbtGovernanceDiagnostics(
+      createProviderInput({
+        metadataResolutions: resolutions,
+      }),
+    )
+      .filter((diagnostic) => diagnostic.code === 'DBT_OWNER_INVALID')
+      .map((diagnostic) => diagnostic.reference?.nodeId);
+
+    expect(ownerInvalidNodeIds).toEqual(['model.analytics.orders']);
   });
 
   it('reports ambiguous interpretation and unsupported profile patterns', () => {

--- a/packages/governance/extension-dbt/src/diagnostics.ts
+++ b/packages/governance/extension-dbt/src/diagnostics.ts
@@ -15,6 +15,7 @@ import {
   getDbtNodes,
   toResolverInput,
 } from './dbt-graph.js';
+import { isDbtOwnershipTarget } from './applicability.js';
 import {
   resolveDbtGovernanceMetadata,
   type DbtGovernanceMetadataResolution,
@@ -135,6 +136,7 @@ function buildDiagnosticsForResolution(
   options: DbtGovernanceDiagnosticsProviderOptions,
 ): DbtGovernanceExtensionDiagnostic[] {
   const diagnostics: DbtGovernanceExtensionDiagnostic[] = [];
+  const ownershipApplicable = isDbtOwnershipTarget(resolution);
 
   appendUnresolvedMetadataDiagnostic(
     diagnostics,
@@ -152,23 +154,27 @@ function buildDiagnosticsForResolution(
     'Domain metadata could not be resolved from normalized dbt governance input.',
     'Populate node.classification.domain or metadata.dbt.resource.meta.domain, or provide a runtime-configured domain resolver convention.',
   );
-  appendUnresolvedMetadataDiagnostic(
-    diagnostics,
-    'DBT_OWNER_MISSING',
-    resolution.owner,
-    'owner',
-    'Owner metadata is missing, so dbt governance interpretation remains incomplete.',
-    'Populate node.ownership.team, metadata.dbt.resource.owner, metadata.dbt.resource.group, or metadata.dbt.resource.meta.owner.',
-  );
+  if (ownershipApplicable) {
+    appendUnresolvedMetadataDiagnostic(
+      diagnostics,
+      'DBT_OWNER_MISSING',
+      resolution.owner,
+      'owner',
+      'Owner metadata is missing, so dbt governance interpretation remains incomplete.',
+      'Populate node.ownership.team, metadata.dbt.resource.owner, metadata.dbt.resource.group, or metadata.dbt.resource.meta.owner.',
+    );
+  }
 
-  appendInvalidMetadataDiagnostic(
-    diagnostics,
-    'DBT_OWNER_INVALID',
-    resolution.owner,
-    'owner',
-    'Owner metadata was present but not in a supported string form.',
-    'Normalize owner metadata to a non-empty string value before running governance interpretation.',
-  );
+  if (ownershipApplicable) {
+    appendInvalidMetadataDiagnostic(
+      diagnostics,
+      'DBT_OWNER_INVALID',
+      resolution.owner,
+      'owner',
+      'Owner metadata was present but not in a supported string form.',
+      'Normalize owner metadata to a non-empty string value before running governance interpretation.',
+    );
+  }
   appendInvalidMetadataDiagnostic(
     diagnostics,
     'DBT_CRITICALITY_INVALID',
@@ -206,7 +212,13 @@ function buildDiagnosticsForResolution(
   );
 
   if (options.includeSkippedRuleDiagnostics ?? true) {
-    appendSkippedRuleDiagnostic(diagnostics, resolution, profile, profileName);
+    appendSkippedRuleDiagnostic(
+      diagnostics,
+      resolution,
+      profile,
+      profileName,
+      ownershipApplicable,
+    );
   }
 
   return diagnostics;
@@ -356,6 +368,7 @@ function appendSkippedRuleDiagnostic(
   resolution: DbtGovernanceMetadataResolution,
   profile: GovernanceProfile,
   profileName: string,
+  ownershipApplicable: boolean,
 ): void {
   const missingMetadata: string[] = [];
   const skippedRuleIds: string[] = [];
@@ -370,7 +383,11 @@ function appendSkippedRuleDiagnostic(
     skippedRuleIds.push('domain-boundary');
   }
 
-  if (profile.ownership.required && resolution.owner.status === 'unresolved') {
+  if (
+    ownershipApplicable &&
+    profile.ownership.required &&
+    resolution.owner.status === 'unresolved'
+  ) {
     missingMetadata.push('owner');
     skippedRuleIds.push('ownership-presence');
   }

--- a/packages/governance/extension-dbt/src/index.ts
+++ b/packages/governance/extension-dbt/src/index.ts
@@ -47,13 +47,18 @@ export {
   type DbtGovernanceWorkspaceExpansionData,
 } from './contracts.js';
 export {
+  isDbtContractTarget,
+  isDbtDagShapeTarget,
   getDbtResolutionResourceType,
   isDbtDocumentationTarget,
   isDbtEvidenceResource,
   isDbtGovernedAssetResolution,
+  isDbtOwnershipResourceType,
+  isDbtOwnershipTarget,
   isDbtPublicModelDocumentationTarget,
   isDbtTestCoverageResourceType,
   isDbtTestCoverageTarget,
+  isDbtWorkspaceContextResource,
 } from './applicability.js';
 export {
   DBT_GOVERNANCE_DIAGNOSTIC_CODES,

--- a/packages/governance/extension-dbt/src/recommendations.spec.ts
+++ b/packages/governance/extension-dbt/src/recommendations.spec.ts
@@ -385,6 +385,151 @@ describe('dbt governance recommendations', () => {
     });
   });
 
+  it('only emits ADD_OWNER for ownership targets and excludes seed ownership by default', () => {
+    const modelNode = createProject({
+      id: 'model.analytics.orders',
+      resourceType: 'model',
+      layer: 'marts',
+      domain: 'finance',
+    });
+    const sourceNode = createProject({
+      id: 'source.analytics.raw.orders',
+      resourceType: 'source',
+      layer: 'staging',
+      domain: 'finance',
+    });
+    const projectNode = createProject({
+      id: 'dbt.project.analytics',
+      resourceType: 'project',
+      layer: 'marts',
+      domain: 'finance',
+    });
+    const testNode = createProject({
+      id: 'test.analytics.not_null_orders_order_id',
+      resourceType: 'test',
+      layer: 'marts',
+      domain: 'finance',
+    });
+    const seedNode = createProject({
+      id: 'seed.analytics.calendar',
+      resourceType: 'seed',
+      layer: 'staging',
+      domain: 'finance',
+    });
+    const workspace = createWorkspace([
+      modelNode,
+      sourceNode,
+      projectNode,
+      testNode,
+      seedNode,
+    ]);
+
+    const addOwnerNodeIds = buildDbtGovernanceRecommendations(
+      createRecommendationInput(workspace, {
+        metadataResolutions: [
+          createResolution(modelNode),
+          createResolution(sourceNode),
+          createResolution(projectNode),
+          createResolution(testNode),
+          createResolution(seedNode),
+        ],
+        diagnostics: [
+          createDiagnostic({
+            id: 'diag-model-owner',
+            code: 'DBT_OWNER_MISSING',
+            nodeId: modelNode.id,
+          }),
+          createDiagnostic({
+            id: 'diag-source-owner',
+            code: 'DBT_OWNER_MISSING',
+            nodeId: sourceNode.id,
+          }),
+          createDiagnostic({
+            id: 'diag-project-owner',
+            code: 'DBT_OWNER_MISSING',
+            nodeId: projectNode.id,
+          }),
+          createDiagnostic({
+            id: 'diag-test-owner',
+            code: 'DBT_OWNER_MISSING',
+            nodeId: testNode.id,
+          }),
+          createDiagnostic({
+            id: 'diag-seed-owner',
+            code: 'DBT_OWNER_MISSING',
+            nodeId: seedNode.id,
+          }),
+        ],
+        signals: [
+          createSignal({
+            id: 'signal-model-owner',
+            code: 'DBT_OWNER_MISSING',
+            nodeId: modelNode.id,
+            dbtUniqueId: modelNode.id,
+          }),
+          createSignal({
+            id: 'signal-source-owner',
+            code: 'DBT_OWNER_MISSING',
+            nodeId: sourceNode.id,
+            dbtUniqueId: sourceNode.id,
+          }),
+          createSignal({
+            id: 'signal-project-owner',
+            code: 'DBT_OWNER_MISSING',
+            nodeId: projectNode.id,
+            dbtUniqueId: projectNode.id,
+          }),
+          createSignal({
+            id: 'signal-test-owner',
+            code: 'DBT_OWNER_MISSING',
+            nodeId: testNode.id,
+            dbtUniqueId: testNode.id,
+          }),
+          createSignal({
+            id: 'signal-seed-owner',
+            code: 'DBT_OWNER_MISSING',
+            nodeId: seedNode.id,
+            dbtUniqueId: seedNode.id,
+          }),
+        ],
+        violations: [
+          createViolation({
+            id: 'violation-model-owner',
+            ruleId: 'dbt/critical-models-require-owner',
+            nodeId: modelNode.id,
+          }),
+          createViolation({
+            id: 'violation-source-owner',
+            ruleId: 'dbt/critical-models-require-owner',
+            nodeId: sourceNode.id,
+          }),
+          createViolation({
+            id: 'violation-project-owner',
+            ruleId: 'dbt/critical-models-require-owner',
+            nodeId: projectNode.id,
+          }),
+          createViolation({
+            id: 'violation-test-owner',
+            ruleId: 'dbt/critical-models-require-owner',
+            nodeId: testNode.id,
+          }),
+          createViolation({
+            id: 'violation-seed-owner',
+            ruleId: 'dbt/critical-models-require-owner',
+            nodeId: seedNode.id,
+          }),
+        ],
+      }),
+    )
+      .filter((recommendation) => recommendation.metadata?.code === 'ADD_OWNER')
+      .map((recommendation) => recommendation.reference?.nodeId);
+
+    expect(addOwnerNodeIds).toEqual([
+      'model.analytics.orders',
+      'source.analytics.raw.orders',
+    ]);
+  });
+
   it('emits ADD_DESCRIPTION from missing-description findings', () => {
     const project = createProject({
       id: 'model.analytics.public_orders',

--- a/packages/governance/extension-dbt/src/recommendations.ts
+++ b/packages/governance/extension-dbt/src/recommendations.ts
@@ -18,7 +18,10 @@ import {
   normalizeIds,
   toResolverInput,
 } from './dbt-graph.js';
-import { isDbtTestCoverageTarget } from './applicability.js';
+import {
+  isDbtOwnershipTarget,
+  isDbtTestCoverageTarget,
+} from './applicability.js';
 import { buildDbtGovernanceDiagnostics } from './diagnostics.js';
 import { buildDbtGovernanceMetrics } from './metrics.js';
 import { evaluateDbtArchitectureViolations } from './rule-pack.js';
@@ -217,6 +220,11 @@ function buildAddOwnerRecommendations(
       continue;
     }
 
+    const resolution = resolutionByNodeId.get(nodeId);
+    if (!resolution || !isDbtOwnershipTarget(resolution)) {
+      continue;
+    }
+
     upsertDraft(
       byNodeId,
       nodeId,
@@ -230,7 +238,7 @@ function buildAddOwnerRecommendations(
           'Add owner metadata using node.ownership.team, metadata.dbt.resource.owner, metadata.dbt.resource.group, or metadata.dbt.resource.meta.owner.',
         category: 'ownership',
         governanceNodeId: nodeId,
-        dbtUniqueId: resolutionByNodeId.get(nodeId)?.dbtUniqueId,
+        dbtUniqueId: resolution.dbtUniqueId,
         diagnostic: {
           id: diagnostic.id,
           code: diagnostic.code,
@@ -241,6 +249,11 @@ function buildAddOwnerRecommendations(
 
   for (const signal of context.signals) {
     if (signal.metadata?.code !== 'DBT_OWNER_MISSING' || !signal.nodeId) {
+      continue;
+    }
+
+    const resolution = resolutionByNodeId.get(signal.nodeId);
+    if (!resolution || !isDbtOwnershipTarget(resolution)) {
       continue;
     }
 
@@ -258,8 +271,7 @@ function buildAddOwnerRecommendations(
         category: 'ownership',
         governanceNodeId: signal.nodeId,
         dbtUniqueId:
-          asString(signal.metadata?.dbtUniqueId) ??
-          resolutionByNodeId.get(signal.nodeId)?.dbtUniqueId,
+          asString(signal.metadata?.dbtUniqueId) ?? resolution.dbtUniqueId,
         signal,
       }),
     );
@@ -272,6 +284,11 @@ function buildAddOwnerRecommendations(
 
     const nodeId = readViolationNodeId(violation);
     if (!nodeId) {
+      continue;
+    }
+
+    const resolution = resolutionByNodeId.get(nodeId);
+    if (!resolution || !isDbtOwnershipTarget(resolution)) {
       continue;
     }
 
@@ -288,7 +305,7 @@ function buildAddOwnerRecommendations(
           'Add explicit owner metadata so the critical model has a clear accountable team.',
         category: 'ownership',
         governanceNodeId: nodeId,
-        dbtUniqueId: resolutionByNodeId.get(nodeId)?.dbtUniqueId,
+        dbtUniqueId: resolution.dbtUniqueId,
         violation,
       }),
     );

--- a/packages/governance/extension-dbt/src/rule-pack.spec.ts
+++ b/packages/governance/extension-dbt/src/rule-pack.spec.ts
@@ -13,9 +13,13 @@ import {
   dbtArchitectureBasicRulePack,
   evaluateDbtArchitectureViolations,
   getDbtResolutionResourceType,
+  isDbtContractTarget,
+  isDbtDagShapeTarget,
   isDbtDocumentationTarget,
+  isDbtOwnershipTarget,
   isDbtPublicModelDocumentationTarget,
   isDbtTestCoverageTarget,
+  isDbtWorkspaceContextResource,
   type DbtGovernanceMetadataResolution,
   type DbtGovernanceRulePackInput,
 } from './index.js';
@@ -437,6 +441,38 @@ describe('dbt architecture basic rule pack', () => {
     );
   });
 
+  it('does not flag critical dbt test, project, or seed nodes for missing owners', () => {
+    const workspace = createWorkspace([
+      createProject({
+        id: 'test.analytics.not_null_critical_orders_order_id',
+        resourceType: 'test',
+        layer: 'marts',
+        domain: 'finance',
+        criticality: 'high',
+      }),
+      createProject({
+        id: 'dbt.project.analytics',
+        resourceType: 'project',
+        layer: 'marts',
+        domain: 'finance',
+        criticality: 'high',
+      }),
+      createProject({
+        id: 'seed.analytics.calendar',
+        resourceType: 'seed',
+        layer: 'staging',
+        domain: 'finance',
+        criticality: 'high',
+      }),
+    ]);
+
+    expect(
+      evaluateDbtArchitectureViolations(createInput(workspace)).some(
+        (violation) => violation.ruleId === 'dbt/critical-models-require-owner',
+      ),
+    ).toBe(false);
+  });
+
   it('flags public models without descriptions', () => {
     const workspace = createWorkspace([
       createProject({
@@ -486,6 +522,54 @@ describe('dbt architecture basic rule pack', () => {
     );
     expect(getDbtResolutionResourceType(legacyTestResolution)).toBe('test');
     expect(isDbtDocumentationTarget(legacyTestResolution)).toBe(false);
+  });
+
+  it('centralizes dbt ownership, workspace-context, contract, and dag-shape applicability', () => {
+    const modelResolution = createResolution({
+      governanceNodeId: 'model.valid_project.orders',
+      dbtUniqueId: 'model.valid_project.orders',
+      resourceType: 'model',
+    });
+    const sourceResolution = createResolution({
+      governanceNodeId: 'source.valid_project.raw.orders',
+      dbtUniqueId: 'source.valid_project.raw.orders',
+      resourceType: 'source',
+    });
+    const projectResolution = createResolution({
+      governanceNodeId: 'dbt.project.valid_project',
+      dbtUniqueId: 'dbt.project.valid_project',
+      resourceType: 'project',
+    });
+    const testResolution = createResolution({
+      governanceNodeId: 'test.valid_project.orders',
+      dbtUniqueId: 'test.valid_project.orders',
+      resourceType: 'test',
+    });
+    const seedResolution = createResolution({
+      governanceNodeId: 'seed.valid_project.calendar',
+      dbtUniqueId: 'seed.valid_project.calendar',
+      resourceType: 'seed',
+    });
+
+    expect(isDbtOwnershipTarget(modelResolution)).toBe(true);
+    expect(isDbtOwnershipTarget(sourceResolution)).toBe(true);
+    expect(isDbtOwnershipTarget(projectResolution)).toBe(false);
+    expect(isDbtOwnershipTarget(testResolution)).toBe(false);
+    expect(isDbtOwnershipTarget(seedResolution)).toBe(false);
+
+    expect(isDbtWorkspaceContextResource(projectResolution)).toBe(true);
+    expect(isDbtWorkspaceContextResource(modelResolution)).toBe(false);
+
+    expect(isDbtContractTarget(modelResolution)).toBe(true);
+    expect(isDbtContractTarget(sourceResolution)).toBe(false);
+    expect(isDbtContractTarget(projectResolution)).toBe(false);
+    expect(isDbtContractTarget(testResolution)).toBe(false);
+
+    expect(isDbtDagShapeTarget(modelResolution)).toBe(true);
+    expect(isDbtDagShapeTarget(sourceResolution)).toBe(true);
+    expect(isDbtDagShapeTarget(seedResolution)).toBe(true);
+    expect(isDbtDagShapeTarget(projectResolution)).toBe(false);
+    expect(isDbtDagShapeTarget(testResolution)).toBe(false);
   });
 
   it('centralizes dbt test coverage applicability for eligible and ineligible resource types', () => {
@@ -849,6 +933,43 @@ describe('dbt architecture basic rule pack', () => {
         }),
       ]),
     );
+  });
+
+  it('does not flag public dbt source, project, or test nodes without contracts', () => {
+    const workspace = createWorkspace([
+      createProject({
+        id: 'source.analytics.raw.orders',
+        resourceType: 'source',
+        layer: 'staging',
+        domain: 'finance',
+        owner: 'finance-platform',
+        publicInterface: true,
+        contract: false,
+      }),
+      createProject({
+        id: 'dbt.project.analytics',
+        resourceType: 'project',
+        layer: 'marts',
+        domain: 'finance',
+        publicInterface: true,
+        contract: false,
+      }),
+      createProject({
+        id: 'test.analytics.not_null_public_orders_order_id',
+        resourceType: 'test',
+        layer: 'marts',
+        domain: 'finance',
+        publicInterface: true,
+        contract: false,
+      }),
+    ]);
+
+    expect(
+      evaluateDbtArchitectureViolations(createInput(workspace)).some(
+        (violation) =>
+          violation.ruleId === 'dbt/public-models-require-contract',
+      ),
+    ).toBe(false);
   });
 
   it('flags cross-domain dependencies without approval metadata', () => {

--- a/packages/governance/extension-dbt/src/rule-pack.ts
+++ b/packages/governance/extension-dbt/src/rule-pack.ts
@@ -19,6 +19,8 @@ import {
   toResolverInput,
 } from './dbt-graph.js';
 import {
+  isDbtContractTarget,
+  isDbtOwnershipTarget,
   isDbtPublicModelDocumentationTarget,
   isDbtTestCoverageTarget,
 } from './applicability.js';
@@ -401,6 +403,10 @@ function evaluateCriticalModelsRequireOwner(
     return [];
   }
 
+  if (!isDbtOwnershipTarget(resolution)) {
+    return [];
+  }
+
   if (
     resolution.criticality.status !== 'resolved' ||
     !resolution.criticality.value
@@ -594,6 +600,7 @@ function evaluatePublicModelsRequireContract(
 
   if (
     !config.enabled ||
+    !isDbtContractTarget(resolution) ||
     resolution.publicInterface.status !== 'resolved' ||
     resolution.publicInterface.value !== true ||
     (resolution.contractPresent.status === 'resolved' &&

--- a/packages/governance/extension-dbt/src/signals.spec.ts
+++ b/packages/governance/extension-dbt/src/signals.spec.ts
@@ -325,6 +325,101 @@ describe('dbt governance signals', () => {
     });
   });
 
+  it('only emits ownership-gap signals for ownership targets and excludes seed ownership by default', () => {
+    const workspace = createWorkspace([
+      createProject({
+        id: 'model.analytics.orders',
+        resourceType: 'model',
+        layer: 'marts',
+        domain: 'finance',
+      }),
+      createProject({
+        id: 'source.analytics.raw.orders',
+        resourceType: 'source',
+        layer: 'staging',
+        domain: 'finance',
+      }),
+      createProject({
+        id: 'test.analytics.not_null_orders_order_id',
+        resourceType: 'test',
+        layer: 'marts',
+        domain: 'finance',
+      }),
+      createProject({
+        id: 'dbt.project.analytics',
+        resourceType: 'project',
+        layer: 'marts',
+        domain: 'finance',
+      }),
+      createProject({
+        id: 'seed.analytics.calendar',
+        resourceType: 'seed',
+        layer: 'staging',
+        domain: 'finance',
+      }),
+    ]);
+
+    const ownershipGapNodeIds = buildDbtGovernanceSignals(
+      createSignalInput(workspace),
+    )
+      .filter((signal) => signal.type === 'ownership-gap')
+      .map((signal) => signal.nodeId)
+      .sort();
+
+    expect(ownershipGapNodeIds).toEqual(
+      ['source.analytics.raw.orders', 'model.analytics.orders'].sort(),
+    );
+  });
+
+  it('does not emit contract signals for dbt project, test, or source nodes', () => {
+    const workspace = createWorkspace([
+      createProject({
+        id: 'model.analytics.public_orders',
+        resourceType: 'model',
+        layer: 'marts',
+        domain: 'finance',
+        publicInterface: true,
+        contract: false,
+      }),
+      createProject({
+        id: 'source.analytics.raw.orders',
+        resourceType: 'source',
+        layer: 'staging',
+        domain: 'finance',
+        publicInterface: true,
+        contract: false,
+      }),
+      createProject({
+        id: 'test.analytics.not_null_public_orders_order_id',
+        resourceType: 'test',
+        layer: 'marts',
+        domain: 'finance',
+        publicInterface: true,
+        contract: false,
+      }),
+      createProject({
+        id: 'dbt.project.analytics',
+        resourceType: 'project',
+        layer: 'marts',
+        domain: 'finance',
+        publicInterface: true,
+        contract: false,
+      }),
+    ]);
+
+    const contractSignalNodeIds = buildDbtGovernanceSignals(
+      createSignalInput(workspace),
+    )
+      .filter(
+        (signal) =>
+          String(signal.metadata?.code ?? '') ===
+          'DBT_CONTRACT_MISSING_FOR_PUBLIC_MODEL_CANDIDATE',
+      )
+      .map((signal) => signal.nodeId);
+
+    expect(contractSignalNodeIds).toEqual(['model.analytics.public_orders']);
+  });
+
   it('does not emit documentation signals for dbt test nodes', () => {
     const workspace = createWorkspace([
       createProject({

--- a/packages/governance/extension-dbt/src/signals.ts
+++ b/packages/governance/extension-dbt/src/signals.ts
@@ -15,7 +15,10 @@ import type {
   DbtGovernanceSignalProviderInput,
 } from './contracts.js';
 import {
+  isDbtContractTarget,
+  isDbtDagShapeTarget,
   isDbtDocumentationTarget,
+  isDbtOwnershipTarget,
   isDbtTestCoverageTarget,
 } from './applicability.js';
 import {
@@ -211,6 +214,7 @@ function buildResourceSignals(
     context.diagnosticsByNodeId,
     resolution.governanceNodeId,
   );
+  const ownershipApplicable = isDbtOwnershipTarget(resolution);
 
   if (resolution.layer.status === 'resolved') {
     const resolvedLayer = resolution.layer.value;
@@ -276,7 +280,7 @@ function buildResourceSignals(
     );
   }
 
-  if (resolution.owner.status === 'resolved') {
+  if (ownershipApplicable && resolution.owner.status === 'resolved') {
     const resolvedOwner = resolution.owner.value;
 
     if (!resolvedOwner) {
@@ -305,7 +309,7 @@ function buildResourceSignals(
         createdAt: context.createdAt,
       }),
     );
-  } else if (resolution.owner.status === 'unresolved') {
+  } else if (ownershipApplicable && resolution.owner.status === 'unresolved') {
     signals.push(
       createSignal({
         code: 'DBT_OWNER_MISSING',
@@ -509,6 +513,10 @@ function appendContractSignals(
   resolution: DbtGovernanceMetadataResolution,
   createdAt: string,
 ): void {
+  if (!isDbtContractTarget(resolution)) {
+    return;
+  }
+
   if (isResolvedTrue(resolution.contractPresent)) {
     signals.push(
       createSignal({
@@ -563,6 +571,10 @@ function appendDagShapeSignals(
   fanOut: number,
   context: DbtSignalContext,
 ): void {
+  if (!isDbtDagShapeTarget(resolution)) {
+    return;
+  }
+
   if (fanIn >= context.options.highFanInThreshold) {
     signals.push(
       createSignal({


### PR DESCRIPTION
closes #453