### PR TITLE
fix(governance-adapter-dbt,governance-extension-dbt): stop canonicalizing dbt tests and project context as governed asset nodes

### DIFF
--- a/packages/governance/adapter-dbt/src/adapter-flow.e2e.spec.ts
+++ b/packages/governance/adapter-dbt/src/adapter-flow.e2e.spec.ts
@@ -27,12 +27,6 @@ describe('dbt adapter flow e2e', () => {
     expect(result).not.toHaveProperty('dependencies');
     expect(result.nodes).toEqual([
       expect.objectContaining({
-        id: 'dbt.project.simple_project',
-        name: 'simple_project',
-        kind: 'project',
-        technology: 'dbt',
-      }),
-      expect.objectContaining({
         id: 'model.simple_project.hello_world',
         name: 'hello_world',
         kind: 'resource',
@@ -56,7 +50,6 @@ describe('dbt adapter flow e2e', () => {
 
     expect(result.nodes?.map((node) => node.id)).toEqual(
       expect.arrayContaining([
-        'dbt.project.layered_project',
         'model.layered_project.stg_orders',
         'model.layered_project.stg_customers',
         'model.layered_project.int_orders_enriched',
@@ -238,10 +231,6 @@ describe('dbt adapter flow e2e', () => {
     expect(result.relations).toEqual([]);
     expect(result.nodes).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({
-          id: 'dbt.project.unresolved_dependency',
-          kind: 'project',
-        }),
         expect.objectContaining({
           id: 'model.unresolved_dependency.orders',
           kind: 'resource',

--- a/packages/governance/adapter-dbt/src/extension-normalization.ts
+++ b/packages/governance/adapter-dbt/src/extension-normalization.ts
@@ -8,6 +8,18 @@ import type { DbtArtifacts, DbtProjectContext } from './contracts.js';
 const DBT_GOVERNANCE_EXTENSION_ID = 'governance-extension:dbt';
 const DBT_GOVERNANCE_EXPANSION_CONTRACT_VERSION = '1';
 
+export interface DbtGovernanceWorkspaceTestEvidence {
+  uniqueId: string;
+  name: string;
+  packageName: string;
+  dependsOnNodeIds: string[];
+  targetNodeIds: string[];
+  originalFilePath?: string;
+  sourcePath?: string;
+  tags?: string[];
+  meta?: Record<string, unknown>;
+}
+
 interface DbtGovernanceWorkspaceExpansionData {
   kind: 'workspace';
   technology: 'dbt';
@@ -15,6 +27,7 @@ interface DbtGovernanceWorkspaceExpansionData {
   projectVersion?: string | number;
   profile?: string;
   configVersion?: number;
+  project?: Record<string, unknown>;
   artifactPaths?: {
     projectDir?: string;
     dbtProjectPath?: string;
@@ -32,6 +45,7 @@ interface DbtGovernanceWorkspaceExpansionData {
     invocationId?: string;
   };
   projectNodeIds?: string[];
+  testEvidence?: DbtGovernanceWorkspaceTestEvidence[];
 }
 
 interface DbtGovernanceNodeExpansionData {
@@ -105,6 +119,7 @@ export function buildDbtWorkspaceExpansion(
   projectContext: DbtProjectContext,
   artifacts: DbtArtifacts,
   projectNodeIds: readonly string[],
+  testEvidence: readonly DbtGovernanceWorkspaceTestEvidence[] = [],
 ) {
   return createDbtGovernanceModelExpansion({
     kind: 'workspace',
@@ -119,6 +134,36 @@ export function buildDbtWorkspaceExpansion(
     ...(artifacts.projectConfig.configVersion !== undefined
       ? { configVersion: artifacts.projectConfig.configVersion }
       : {}),
+    project: {
+      name: artifacts.projectConfig.name,
+      ...(artifacts.projectConfig.version !== undefined
+        ? { version: artifacts.projectConfig.version }
+        : {}),
+      ...(artifacts.projectConfig.configVersion !== undefined
+        ? { configVersion: artifacts.projectConfig.configVersion }
+        : {}),
+      ...(artifacts.projectConfig.profile
+        ? { profile: artifacts.projectConfig.profile }
+        : {}),
+      ...(artifacts.projectConfig.modelPaths
+        ? { modelPaths: artifacts.projectConfig.modelPaths }
+        : {}),
+      ...(artifacts.projectConfig.seedPaths
+        ? { seedPaths: artifacts.projectConfig.seedPaths }
+        : {}),
+      ...(artifacts.projectConfig.snapshotPaths
+        ? { snapshotPaths: artifacts.projectConfig.snapshotPaths }
+        : {}),
+      ...(artifacts.projectConfig.analysisPaths
+        ? { analysisPaths: artifacts.projectConfig.analysisPaths }
+        : {}),
+      ...(artifacts.projectConfig.macroPaths
+        ? { macroPaths: artifacts.projectConfig.macroPaths }
+        : {}),
+      ...(artifacts.projectConfig.testPaths
+        ? { testPaths: artifacts.projectConfig.testPaths }
+        : {}),
+    },
     artifactPaths: {
       projectDir: projectContext.projectDir,
       dbtProjectPath: projectContext.dbtProjectPath,
@@ -150,21 +195,26 @@ export function buildDbtWorkspaceExpansion(
         : {}),
     },
     projectNodeIds: [...projectNodeIds].sort(),
+    ...(testEvidence.length > 0
+      ? {
+          testEvidence: [...testEvidence]
+            .map((entry) => ({
+              uniqueId: entry.uniqueId,
+              name: entry.name,
+              packageName: entry.packageName,
+              dependsOnNodeIds: [...entry.dependsOnNodeIds].sort(),
+              targetNodeIds: [...entry.targetNodeIds].sort(),
+              ...(entry.originalFilePath
+                ? { originalFilePath: entry.originalFilePath }
+                : {}),
+              ...(entry.sourcePath ? { sourcePath: entry.sourcePath } : {}),
+              ...(entry.tags ? { tags: [...entry.tags].sort() } : {}),
+              ...(entry.meta ? { meta: structuredClone(entry.meta) } : {}),
+            }))
+            .sort((left, right) => left.uniqueId.localeCompare(right.uniqueId)),
+        }
+      : {}),
   } satisfies DbtGovernanceWorkspaceExpansionData);
-}
-
-export function buildDbtProjectNodeExpansion(
-  metadata: Record<string, unknown>,
-) {
-  return createDbtGovernanceModelExpansion({
-    kind: 'node',
-    technology: 'dbt',
-    nodeKind: 'project',
-    resourceType: 'project',
-    project: readRecord(metadata, 'project'),
-    identity: readRecord(metadata, 'identity'),
-    relation: readRecord(metadata, 'relation'),
-  } satisfies DbtGovernanceNodeExpansionData);
 }
 
 export function buildDbtResourceNodeExpansion(

--- a/packages/governance/adapter-dbt/src/normalize-dbt-artifacts.spec.ts
+++ b/packages/governance/adapter-dbt/src/normalize-dbt-artifacts.spec.ts
@@ -19,6 +19,7 @@ interface DbtNodeExpansionEnvelope {
   data: {
     kind: 'node';
     nodeKind: 'project' | 'resource' | 'unknown';
+    resourceType?: string;
     resource?: Record<string, unknown>;
   };
 }
@@ -40,6 +41,9 @@ interface DbtWorkspaceExpansionEnvelope {
     kind: 'workspace';
     technology?: string;
     projectName: string;
+    project?: Record<string, unknown>;
+    projectNodeIds?: string[];
+    testEvidence?: Array<Record<string, unknown>>;
   };
 }
 
@@ -60,15 +64,17 @@ describe('dbt artifact normalization', () => {
     expect(normalized.relations?.length).toBeGreaterThan(0);
   });
 
-  it('normalizes the dbt project, models, sources, seeds, snapshots, and exposures into canonical nodes', () => {
+  it('normalizes models, sources, seeds, snapshots, and exposures into canonical nodes while keeping project context at workspace level', () => {
     const context = mustResolveContext('valid-project');
     const artifacts = mustLoadArtifacts(context);
     const normalized = normalizeDbtArtifacts(context, artifacts);
     const nodeIds = normalized.nodes?.map((node) => node.id) ?? [];
+    const workspaceExpansion = normalized.extensions?.[
+      'governance-extension:dbt'
+    ] as DbtWorkspaceExpansionEnvelope | undefined;
 
     expect(nodeIds).toEqual(
       expect.arrayContaining([
-        'dbt.project.valid_project',
         'model.valid_project.stg_orders',
         'model.valid_project.orders',
         'model.valid_project.orders_regional',
@@ -78,29 +84,26 @@ describe('dbt artifact normalization', () => {
         'exposure.valid_project.executive_dashboard',
       ]),
     );
+    expect(nodeIds).not.toContain('dbt.project.valid_project');
+    expect(nodeIds.some((nodeId) => nodeId.startsWith('dbt.project.'))).toBe(
+      false,
+    );
+    expect(nodeIds.some((nodeId) => nodeId.startsWith('test.'))).toBe(false);
 
-    expect(
-      normalized.nodes?.find((node) => node.id === 'dbt.project.valid_project'),
-    ).toMatchObject({
-      kind: 'project',
-      technology: 'dbt',
-      sourceSystem: 'dbt',
-      extensions: {
-        'governance-extension:dbt': expect.objectContaining({
-          data: expect.objectContaining({
-            kind: 'node',
-            nodeKind: 'project',
-            resourceType: 'project',
-            identity: expect.objectContaining({
-              projectName: 'valid_project',
-              resourceType: 'project',
-            }),
-            project: expect.objectContaining({
-              name: 'valid_project',
-              profile: 'analytics',
-            }),
-          }),
+    expect(workspaceExpansion).toMatchObject({
+      data: {
+        kind: 'workspace',
+        technology: 'dbt',
+        projectName: 'valid_project',
+        project: expect.objectContaining({
+          name: 'valid_project',
+          profile: 'analytics',
         }),
+        projectNodeIds: expect.arrayContaining([
+          'model.valid_project.orders',
+          'source.valid_project.raw.orders',
+          'seed.valid_project.countries',
+        ]),
       },
     });
 
@@ -208,6 +211,163 @@ describe('dbt artifact normalization', () => {
         }),
       },
     });
+  });
+
+  it('keeps dbt test evidence in workspace expansion instead of canonical nodes', () => {
+    const context = mustResolveContext('valid-project');
+    const normalized = normalizeDbtArtifacts(context, {
+      manifest: buildSyntheticManifestFromResources([
+        [
+          'source.valid_project.raw.orders',
+          {
+            resource_type: 'source',
+            unique_id: 'source.valid_project.raw.orders',
+            package_name: 'valid_project',
+            name: 'orders',
+            source_name: 'raw',
+            relation_name: '"warehouse"."raw"."orders"',
+            original_file_path: 'models/raw/raw.yml',
+            tags: ['raw'],
+            tests: ['freshness'],
+          },
+        ],
+        [
+          'seed.valid_project.countries',
+          {
+            resource_type: 'seed',
+            unique_id: 'seed.valid_project.countries',
+            package_name: 'valid_project',
+            name: 'countries',
+            relation_name: '"analytics"."reference"."countries"',
+            original_file_path: 'seeds/countries.csv',
+            tests: ['unique:country_code'],
+            config: {
+              materialized: 'seed',
+            },
+          },
+        ],
+        [
+          'model.valid_project.orders',
+          {
+            resource_type: 'model',
+            unique_id: 'model.valid_project.orders',
+            package_name: 'valid_project',
+            name: 'orders',
+            relation_name: '"analytics"."marts"."orders"',
+            original_file_path: 'models/marts/orders.sql',
+            tests: false,
+            config: {
+              materialized: 'table',
+              contract: {
+                enforced: true,
+              },
+            },
+            depends_on: {
+              nodes: [
+                'source.valid_project.raw.orders',
+                'seed.valid_project.countries',
+              ],
+            },
+          },
+        ],
+        [
+          'test.valid_project.relationships_orders_country_code',
+          {
+            resource_type: 'test',
+            unique_id: 'test.valid_project.relationships_orders_country_code',
+            package_name: 'valid_project',
+            name: 'relationships_orders_country_code',
+            original_file_path:
+              'tests/generic/relationships_orders_country_code.sql',
+            tags: ['critical', 'relationships'],
+            meta: {
+              severity: 'error',
+            },
+            depends_on: {
+              nodes: [
+                'model.valid_project.orders',
+                'seed.valid_project.countries',
+              ],
+            },
+          },
+        ],
+      ]),
+      projectConfig: {
+        name: 'valid_project',
+        profile: 'analytics',
+        modelPaths: ['models'],
+        seedPaths: ['seeds'],
+        testPaths: ['tests'],
+      },
+    });
+    const workspaceExpansion = normalized.extensions?.[
+      'governance-extension:dbt'
+    ] as DbtWorkspaceExpansionEnvelope | undefined;
+    const nodeIds = normalized.nodes?.map((node) => node.id) ?? [];
+
+    expect(nodeIds).toEqual(
+      expect.arrayContaining([
+        'model.valid_project.orders',
+        'source.valid_project.raw.orders',
+        'seed.valid_project.countries',
+      ]),
+    );
+    expect(nodeIds).not.toContain(
+      'test.valid_project.relationships_orders_country_code',
+    );
+    expect(
+      normalized.nodes?.some((node) => {
+        const expansion = getDbtNodeExpansion(node);
+        return expansion?.data.resourceType === 'test';
+      }),
+    ).toBe(false);
+
+    expect(workspaceExpansion).toMatchObject({
+      data: {
+        project: expect.objectContaining({
+          name: 'valid_project',
+          profile: 'analytics',
+          modelPaths: ['models'],
+          seedPaths: ['seeds'],
+          testPaths: ['tests'],
+        }),
+        testEvidence: [
+          expect.objectContaining({
+            uniqueId: 'test.valid_project.relationships_orders_country_code',
+            name: 'relationships_orders_country_code',
+            packageName: 'valid_project',
+            dependsOnNodeIds: [
+              'model.valid_project.orders',
+              'seed.valid_project.countries',
+            ],
+            targetNodeIds: [
+              'model.valid_project.orders',
+              'seed.valid_project.countries',
+            ],
+            originalFilePath:
+              'tests/generic/relationships_orders_country_code.sql',
+            tags: ['critical', 'relationships'],
+            meta: {
+              severity: 'error',
+            },
+          }),
+        ],
+      },
+    });
+    expect(normalized.relations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceNodeId: 'model.valid_project.orders',
+          targetNodeId: 'source.valid_project.raw.orders',
+          kind: 'dependency',
+        }),
+        expect.objectContaining({
+          sourceNodeId: 'model.valid_project.orders',
+          targetNodeId: 'seed.valid_project.countries',
+          kind: 'dependency',
+        }),
+      ]),
+    );
   });
 
   it('preserves stable dbt identifiers and metadata on canonical nodes', () => {
@@ -1081,17 +1241,6 @@ describe('dbt artifact normalization', () => {
     const workspaceExpansion = normalized.extensions?.[
       'governance-extension:dbt'
     ] as DbtWorkspaceExpansionEnvelope | undefined;
-    const projectNodeExpansion = normalized.nodes
-      ?.flatMap((node) => {
-        const expansion = node.extensions?.['governance-extension:dbt'] as
-          | DbtNodeExpansionEnvelope
-          | undefined;
-        return expansion?.data.kind === 'node' &&
-          expansion.data.nodeKind === 'project'
-          ? [expansion]
-          : [];
-      })
-      .at(0);
     const resourceNodeExpansion = normalized.nodes
       ?.flatMap((node) => {
         const expansion = node.extensions?.['governance-extension:dbt'] as
@@ -1112,31 +1261,21 @@ describe('dbt artifact normalization', () => {
       })
       .at(0);
 
-    [
-      workspaceExpansion,
-      projectNodeExpansion,
-      resourceNodeExpansion,
-      relationExpansion,
-    ].forEach((expansion) => {
-      expect(expansion).toBeDefined();
-      expect(expansion).toMatchObject({
-        extensionId: 'governance-extension:dbt',
-        contractVersion: '1',
-      });
-    });
+    [workspaceExpansion, resourceNodeExpansion, relationExpansion].forEach(
+      (expansion) => {
+        expect(expansion).toBeDefined();
+        expect(expansion).toMatchObject({
+          extensionId: 'governance-extension:dbt',
+          contractVersion: '1',
+        });
+      },
+    );
 
     expect(workspaceExpansion).toMatchObject({
       data: {
         kind: 'workspace',
         technology: 'dbt',
         projectName: 'valid_project',
-      },
-    });
-    expect(projectNodeExpansion).toMatchObject({
-      data: {
-        kind: 'node',
-        technology: 'dbt',
-        nodeKind: 'project',
       },
     });
     expect(resourceNodeExpansion).toMatchObject({
@@ -1219,36 +1358,43 @@ function buildSyntheticManifest(
   uniqueId: string,
   resource: DbtManifestResource,
 ): DbtArtifacts['manifest'] {
-  const resourceType =
-    typeof resource.resource_type === 'string'
-      ? resource.resource_type
-      : 'model';
-  const entry = {
-    resource_type: resourceType,
-    unique_id: uniqueId,
-    package_name: 'valid_project',
-    name: 'synthetic_owner_case',
-    ...(resourceType === 'source' ? { source_name: 'synthetic_source' } : {}),
-    ...resource,
-  };
+  return buildSyntheticManifestFromResources([[uniqueId, resource]]);
+}
+
+function buildSyntheticManifestFromResources(
+  resources: ReadonlyArray<readonly [string, DbtManifestResource]>,
+): DbtArtifacts['manifest'] {
+  const nodes: Record<string, DbtManifestResource> = {};
+  const sources: Record<string, DbtManifestResource> = {};
+
+  for (const [uniqueId, resource] of resources) {
+    const resourceType =
+      typeof resource.resource_type === 'string'
+        ? resource.resource_type
+        : 'model';
+    const entry = {
+      resource_type: resourceType,
+      unique_id: uniqueId,
+      package_name: 'valid_project',
+      name: 'synthetic_owner_case',
+      ...(resourceType === 'source' ? { source_name: 'synthetic_source' } : {}),
+      ...resource,
+    };
+
+    if (resourceType === 'source') {
+      sources[uniqueId] = entry;
+      continue;
+    }
+
+    nodes[uniqueId] = entry;
+  }
 
   return {
     metadata: {
       dbt_schema_version: 'https://schemas.getdbt.com/dbt/manifest/v12.json',
       project_name: 'valid_project',
     },
-    nodes:
-      resourceType === 'source'
-        ? {}
-        : {
-            [uniqueId]: entry,
-          },
-    ...(resourceType === 'source'
-      ? {
-          sources: {
-            [uniqueId]: entry,
-          },
-        }
-      : {}),
+    nodes,
+    ...(Object.keys(sources).length > 0 ? { sources } : {}),
   };
 }

--- a/packages/governance/adapter-dbt/src/normalize-dbt-artifacts.ts
+++ b/packages/governance/adapter-dbt/src/normalize-dbt-artifacts.ts
@@ -27,9 +27,9 @@ import {
   unsupportedDbtResourceShapeDiagnostic,
 } from './diagnostics.js';
 import {
-  buildDbtProjectNodeExpansion,
   buildDbtRelationExpansion,
   buildDbtResourceNodeExpansion,
+  type DbtGovernanceWorkspaceTestEvidence,
   buildDbtWorkspaceExpansion,
 } from './extension-normalization.js';
 
@@ -58,11 +58,6 @@ const DBT_MANIFEST_SOURCE = {
   id: 'dbt-manifest',
   name: 'dbt manifest',
   type: 'artifact',
-} as const;
-const DBT_PROJECT_SOURCE = {
-  id: 'dbt-project-config',
-  name: 'dbt project config',
-  type: 'configuration',
 } as const;
 
 type ResourceRecord = Record<string, unknown>;
@@ -117,12 +112,25 @@ export function normalizeDbtArtifacts(
 ): DbtAdapterResult {
   const diagnostics: DbtAdapterDiagnostic[] = [];
   const normalizedResourcesById = new Map<string, NormalizedResource>();
+  const workspaceTestEvidence: DbtGovernanceWorkspaceTestEvidence[] = [];
   let skippedCount = 0;
   let invalidCount = 0;
 
   for (const [, resource] of collectManifestResourceEntries(
     artifacts.manifest,
   )) {
+    const resourceType = readManifestResourceType(resource);
+    if (
+      isSupportedResourceType(resourceType) &&
+      !isCanonicalDbtAssetResourceType(resourceType)
+    ) {
+      const testEvidence = normalizeDbtTestEvidence(resource, projectContext);
+      if (testEvidence) {
+        workspaceTestEvidence.push(testEvidence);
+      }
+      continue;
+    }
+
     const normalized = normalizeDbtManifestResource(
       resource,
       projectContext,
@@ -151,7 +159,6 @@ export function normalizeDbtArtifacts(
     );
   }
 
-  const projectNode = buildDbtProjectNode(projectContext, artifacts);
   const relationMapping = mapDbtRelations(
     artifacts.manifest,
     normalizedResourcesById,
@@ -173,10 +180,9 @@ export function normalizeDbtArtifacts(
     );
   }
 
-  const nodes = [
-    projectNode,
-    ...[...normalizedResourcesById.values()].map((entry) => entry.node),
-  ].sort((left, right) => left.id.localeCompare(right.id));
+  const nodes = [...normalizedResourcesById.values()]
+    .map((entry) => entry.node)
+    .sort((left, right) => left.id.localeCompare(right.id));
   const relations = [...relationMapping.relations].sort(
     (left, right) =>
       (left.id ?? '').localeCompare(right.id ?? '') ||
@@ -197,77 +203,13 @@ export function normalizeDbtArtifacts(
         projectContext,
         artifacts,
         nodes.map((node) => node.id),
+        workspaceTestEvidence,
       ),
     },
     metadata: {
       adapter: 'dbt',
       paths: projectContext.artifactPaths,
     },
-  };
-}
-
-function buildDbtProjectNode(
-  projectContext: DbtProjectContext,
-  artifacts: DbtArtifacts,
-): GovernanceNodeInput {
-  const dbtMetadata = {
-    identity: {
-      projectName: artifacts.projectConfig.name,
-      resourceType: 'project',
-    },
-    project: {
-      name: artifacts.projectConfig.name,
-      ...(artifacts.projectConfig.version !== undefined
-        ? { version: artifacts.projectConfig.version }
-        : {}),
-      ...(artifacts.projectConfig.configVersion !== undefined
-        ? { configVersion: artifacts.projectConfig.configVersion }
-        : {}),
-      ...(artifacts.projectConfig.profile
-        ? { profile: artifacts.projectConfig.profile }
-        : {}),
-      ...(artifacts.projectConfig.modelPaths
-        ? { modelPaths: artifacts.projectConfig.modelPaths }
-        : {}),
-      ...(artifacts.projectConfig.seedPaths
-        ? { seedPaths: artifacts.projectConfig.seedPaths }
-        : {}),
-      ...(artifacts.projectConfig.snapshotPaths
-        ? { snapshotPaths: artifacts.projectConfig.snapshotPaths }
-        : {}),
-      ...(artifacts.projectConfig.analysisPaths
-        ? { analysisPaths: artifacts.projectConfig.analysisPaths }
-        : {}),
-      ...(artifacts.projectConfig.macroPaths
-        ? { macroPaths: artifacts.projectConfig.macroPaths }
-        : {}),
-      ...(artifacts.projectConfig.testPaths
-        ? { testPaths: artifacts.projectConfig.testPaths }
-        : {}),
-    },
-    relation: {
-      projectDir: projectContext.projectDir,
-      dbtProjectPath: projectContext.dbtProjectPath,
-      manifestPath: projectContext.artifactPaths.manifestPath,
-    },
-  } satisfies Record<string, unknown>;
-
-  return {
-    id: buildDbtProjectNodeId(artifacts.projectConfig.name),
-    name: artifacts.projectConfig.name,
-    kind: 'project',
-    technology: 'dbt',
-    sourceSystem: 'dbt',
-    root: projectContext.projectDir,
-    path: projectContext.dbtProjectPath,
-    tags: [],
-    source: DBT_PROJECT_SOURCE,
-    authority: 'documented',
-    confidence: 1,
-    extensions: {
-      'governance-extension:dbt': buildDbtProjectNodeExpansion(dbtMetadata),
-    },
-    metadata: {},
   };
 }
 
@@ -676,6 +618,43 @@ function normalizeDbtManifestResource(
   };
 }
 
+function normalizeDbtTestEvidence(
+  resource: DbtManifestResource,
+  projectContext: DbtProjectContext,
+): DbtGovernanceWorkspaceTestEvidence | undefined {
+  const record = asRecord(resource);
+  if (!record) {
+    return undefined;
+  }
+
+  const uniqueId = readOptionalString(record.unique_id);
+  const name = readOptionalString(record.name);
+  const packageName = readOptionalString(record.package_name);
+  if (!uniqueId || !name || !packageName) {
+    return undefined;
+  }
+
+  const dependsOn = readDependsOnNodeIds(record, uniqueId, []);
+  const originalFilePath = readOptionalString(record.original_file_path);
+  const sourcePath = originalFilePath
+    ? path.join(projectContext.projectDir, originalFilePath)
+    : undefined;
+  const tags = readStringArray(record.tags);
+  const meta = asRecord(record.meta);
+
+  return {
+    uniqueId,
+    name,
+    packageName,
+    dependsOnNodeIds: [...dependsOn.nodeIds].sort(),
+    targetNodeIds: [...dependsOn.nodeIds].sort(),
+    ...(originalFilePath ? { originalFilePath } : {}),
+    ...(sourcePath ? { sourcePath } : {}),
+    ...(tags.length > 0 ? { tags } : {}),
+    ...(meta ? { meta: cloneStructuredValue(meta) } : {}),
+  };
+}
+
 function buildDbtResourceMetadata(
   resource: ResourceRecord,
   options: {
@@ -1067,10 +1046,6 @@ function cloneStructuredValue<T>(value: T): T {
   return value;
 }
 
-function buildDbtProjectNodeId(projectName: string): string {
-  return `dbt.project.${projectName}`;
-}
-
 function toCanonicalNodeKind(
   _resourceType: string,
 ): GovernanceNodeInput['kind'] {
@@ -1106,14 +1081,21 @@ function buildDbtRelationId(
   return `dbt:${relationKind}:${sourceNodeId}->${targetNodeId}`;
 }
 
+function readManifestResourceType(resource: DbtManifestResource): string {
+  const record = asRecord(resource);
+  return readOptionalString(record?.resource_type) ?? 'unknown';
+}
+
+function isCanonicalDbtAssetResourceType(resourceType: string): boolean {
+  return resourceType !== 'test' && isSupportedResourceType(resourceType);
+}
+
 function isSupportedResourceType(resourceType: string): boolean {
   return SUPPORTED_RESOURCE_TYPES.has(resourceType);
 }
 
 function isSkippedResource(resource: DbtManifestResource): boolean {
-  const record = asRecord(resource);
-  const resourceType = readOptionalString(record?.resource_type) ?? 'unknown';
-  return !isSupportedResourceType(resourceType);
+  return !isSupportedResourceType(readManifestResourceType(resource));
 }
 
 function asRecord(value: unknown): ResourceRecord | undefined {

--- a/packages/governance/extension-dbt/src/contracts.ts
+++ b/packages/governance/extension-dbt/src/contracts.ts
@@ -44,6 +44,7 @@ export interface DbtGovernanceWorkspaceExpansionData {
   projectVersion?: string | number;
   profile?: string;
   configVersion?: number;
+  project?: Record<string, unknown>;
   artifactPaths?: {
     projectDir?: string;
     dbtProjectPath?: string;
@@ -61,6 +62,19 @@ export interface DbtGovernanceWorkspaceExpansionData {
     invocationId?: string;
   };
   projectNodeIds?: string[];
+  testEvidence?: DbtGovernanceWorkspaceTestEvidence[];
+}
+
+export interface DbtGovernanceWorkspaceTestEvidence {
+  uniqueId: string;
+  name: string;
+  packageName: string;
+  dependsOnNodeIds: string[];
+  targetNodeIds: string[];
+  originalFilePath?: string;
+  sourcePath?: string;
+  tags?: string[];
+  meta?: Record<string, unknown>;
 }
 
 export interface DbtGovernanceNodeExpansionData {
@@ -473,11 +487,17 @@ export function validateDbtGovernanceModelExpansion(
 
   switch (data.kind) {
     case 'workspace':
+      validateOptionalRecord(data.project, '/data/project', issues);
       validateOptionalRecord(data.artifactPaths, '/data/artifactPaths', issues);
       validateOptionalRecord(data.manifest, '/data/manifest', issues);
       validateOptionalStringArray(
         data.projectNodeIds,
         '/data/projectNodeIds',
+        issues,
+      );
+      validateOptionalRecordArray(
+        data.testEvidence,
+        '/data/testEvidence',
         issues,
       );
       break;
@@ -571,6 +591,24 @@ function validateOptionalStringArray(
       code: 'dbt.expansion.invalid_string_array',
       severity: 'error',
       message: 'Expected a non-empty string array when present.',
+      path,
+    });
+  }
+}
+
+function validateOptionalRecordArray(
+  value: unknown,
+  path: string,
+  issues: GovernanceExtensionContractIssue[],
+): void {
+  if (
+    value !== undefined &&
+    (!Array.isArray(value) || value.some((entry) => !isRecord(entry)))
+  ) {
+    issues.push({
+      code: 'dbt.expansion.invalid_array',
+      severity: 'error',
+      message: 'Expected an array of objects.',
       path,
     });
   }

--- a/packages/governance/extension-dbt/src/dbt-graph.ts
+++ b/packages/governance/extension-dbt/src/dbt-graph.ts
@@ -7,6 +7,8 @@ import type {
 } from '@anarchitects/governance-core';
 
 import type {
+  DbtGovernanceWorkspaceExpansionData,
+  DbtGovernanceWorkspaceTestEvidence,
   DbtGovernanceModelExpansionData,
   DbtGovernanceNodeExpansionData,
   DbtGovernanceRelationExpansionData,
@@ -161,27 +163,10 @@ export function toResolverInput(
 export function buildDbtInferredTestNodeIdsByTarget(
   workspace: GovernanceWorkspace,
 ): ReadonlyMap<string, readonly string[]> {
-  const nodeById = indexNodesById(workspace.nodes);
   const inferredByTarget = new Map<string, Set<string>>();
 
-  for (const relation of getDbtRelations(workspace)) {
-    const sourceNode = nodeById.get(relation.sourceNodeId);
-    const targetNode = nodeById.get(relation.targetNodeId);
-
-    if (
-      !sourceNode ||
-      !targetNode ||
-      !isDbtTestNode(sourceNode) ||
-      !isDbtTestCoverageTarget(targetNode)
-    ) {
-      continue;
-    }
-
-    const inferredTestNodeIds =
-      inferredByTarget.get(targetNode.id) ?? new Set<string>();
-    inferredTestNodeIds.add(sourceNode.id);
-    inferredByTarget.set(targetNode.id, inferredTestNodeIds);
-  }
+  collectInferredTestNodeIdsFromRelations(workspace, inferredByTarget);
+  collectInferredTestNodeIdsFromWorkspaceEvidence(workspace, inferredByTarget);
 
   return new Map(
     [...inferredByTarget.entries()].map(([targetNodeId, testNodeIds]) => [
@@ -271,26 +256,99 @@ function getDbtRelationExpansionData(
 }
 
 function buildWorkspaceDbtMetadata(
-  expansion: Extract<DbtGovernanceModelExpansionData, { kind: 'workspace' }>,
+  expansion: DbtGovernanceWorkspaceExpansionData,
 ): Record<string, unknown> {
-  return {
-    ...(expansion.projectName
+  const project =
+    expansion.project ??
+    (expansion.projectName
       ? {
-          project: {
-            name: expansion.projectName,
-            ...(expansion.projectVersion !== undefined
-              ? { version: expansion.projectVersion }
-              : {}),
-            ...(expansion.profile ? { profile: expansion.profile } : {}),
-            ...(expansion.configVersion !== undefined
-              ? { configVersion: expansion.configVersion }
-              : {}),
-          },
+          name: expansion.projectName,
+          ...(expansion.projectVersion !== undefined
+            ? { version: expansion.projectVersion }
+            : {}),
+          ...(expansion.profile ? { profile: expansion.profile } : {}),
+          ...(expansion.configVersion !== undefined
+            ? { configVersion: expansion.configVersion }
+            : {}),
         }
-      : {}),
+      : undefined);
+
+  return {
+    ...(project ? { project } : {}),
     ...(expansion.manifest ? { manifest: expansion.manifest } : {}),
     ...(expansion.artifactPaths ? { paths: expansion.artifactPaths } : {}),
+    ...(expansion.projectNodeIds
+      ? { projectNodeIds: expansion.projectNodeIds }
+      : {}),
+    ...(expansion.testEvidence ? { testEvidence: expansion.testEvidence } : {}),
   };
+}
+
+function collectInferredTestNodeIdsFromRelations(
+  workspace: GovernanceWorkspace,
+  inferredByTarget: Map<string, Set<string>>,
+): void {
+  const nodeById = indexNodesById(workspace.nodes);
+
+  for (const relation of getDbtRelations(workspace)) {
+    const sourceNode = nodeById.get(relation.sourceNodeId);
+    const targetNode = nodeById.get(relation.targetNodeId);
+
+    if (
+      !sourceNode ||
+      !targetNode ||
+      !isDbtTestNode(sourceNode) ||
+      !isDbtTestCoverageTarget(targetNode)
+    ) {
+      continue;
+    }
+
+    const inferredTestNodeIds =
+      inferredByTarget.get(targetNode.id) ?? new Set<string>();
+    inferredTestNodeIds.add(sourceNode.id);
+    inferredByTarget.set(targetNode.id, inferredTestNodeIds);
+  }
+}
+
+function collectInferredTestNodeIdsFromWorkspaceEvidence(
+  workspace: GovernanceWorkspace,
+  inferredByTarget: Map<string, Set<string>>,
+): void {
+  for (const evidence of getDbtWorkspaceTestEvidence(workspace)) {
+    for (const targetNodeId of evidence.targetNodeIds) {
+      const inferredTestNodeIds =
+        inferredByTarget.get(targetNodeId) ?? new Set<string>();
+      inferredTestNodeIds.add(evidence.uniqueId);
+      inferredByTarget.set(targetNodeId, inferredTestNodeIds);
+    }
+  }
+}
+
+function getDbtWorkspaceTestEvidence(
+  workspace: GovernanceWorkspace,
+): readonly DbtGovernanceWorkspaceTestEvidence[] {
+  const expansion = getDbtExpansionData(workspace);
+  if (
+    expansion?.kind !== 'workspace' ||
+    !Array.isArray(expansion.testEvidence)
+  ) {
+    return [];
+  }
+
+  return expansion.testEvidence.filter(isDbtWorkspaceTestEvidence);
+}
+
+function isDbtWorkspaceTestEvidence(
+  value: unknown,
+): value is DbtGovernanceWorkspaceTestEvidence {
+  return (
+    isRecord(value) &&
+    typeof value.uniqueId === 'string' &&
+    typeof value.name === 'string' &&
+    typeof value.packageName === 'string' &&
+    Array.isArray(value.targetNodeIds) &&
+    value.targetNodeIds.every((entry) => typeof entry === 'string')
+  );
 }
 
 function buildNodeDbtMetadata(

--- a/packages/governance/extension-dbt/src/signals.spec.ts
+++ b/packages/governance/extension-dbt/src/signals.spec.ts
@@ -489,6 +489,49 @@ describe('dbt governance signals', () => {
     expect(modelSignalCodes).not.toContain('DBT_TESTS_MISSING');
   });
 
+  it('treats workspace dbt test evidence linked to a model as test coverage', () => {
+    const modelId = 'model.analytics.orders';
+    const workspace: GovernanceWorkspace = {
+      ...createWorkspace([
+        createProject({
+          id: modelId,
+          layer: 'marts',
+          domain: 'finance',
+          tests: false,
+        }),
+      ]),
+      extensions: {
+        'governance-extension:dbt': {
+          extensionId: 'governance-extension:dbt',
+          contractVersion: '1',
+          data: {
+            kind: 'workspace',
+            technology: 'dbt',
+            projectName: 'analytics',
+            testEvidence: [
+              {
+                uniqueId: 'test.analytics.not_null_orders_order_id',
+                name: 'not_null_orders_order_id',
+                packageName: 'analytics',
+                dependsOnNodeIds: [modelId],
+                targetNodeIds: [modelId],
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const modelSignalCodes = buildDbtGovernanceSignals(
+      createSignalInput(workspace),
+    )
+      .filter((signal) => signal.nodeId === modelId)
+      .map((signal) => String(signal.metadata?.code ?? ''));
+
+    expect(modelSignalCodes).toContain('DBT_TESTS_PRESENT');
+    expect(modelSignalCodes).not.toContain('DBT_TESTS_MISSING');
+  });
+
   it('treats dbt source tests linked to a source as test coverage', () => {
     const sourceId = 'source.analytics.raw.orders';
     const workspace = createWorkspace(

--- a/packages/governance/runtime-dbt/src/runtime.spec.ts
+++ b/packages/governance/runtime-dbt/src/runtime.spec.ts
@@ -34,15 +34,16 @@ describe('runDbtGovernanceRuntime', () => {
     expect(result.workspace?.nodes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          id: 'dbt.project.layered_project',
-          kind: 'project',
-        }),
-        expect.objectContaining({
           id: 'model.layered_project.fct_orders',
           kind: 'resource',
         }),
       ]),
     );
+    expect(
+      result.workspace?.nodes.some(
+        (node) => node.id === 'dbt.project.layered_project',
+      ),
+    ).toBe(false);
     expect(result.workspace?.relations).toEqual(
       expect.arrayContaining([
         expect.objectContaining({


### PR DESCRIPTION
closes #485