### PR TITLE
fix(governance-adapter-dbt,governance-extension-dbt): keep dbt test evidence out of canonical governance relations

### DIFF
--- a/packages/governance/adapter-dbt/src/extension-normalization.ts
+++ b/packages/governance/adapter-dbt/src/extension-normalization.ts
@@ -12,6 +12,8 @@ export interface DbtGovernanceWorkspaceTestEvidence {
   uniqueId: string;
   name: string;
   packageName: string;
+  resourceType: 'test';
+  testType?: string;
   dependsOnNodeIds: string[];
   targetNodeIds: string[];
   originalFilePath?: string;
@@ -202,6 +204,8 @@ export function buildDbtWorkspaceExpansion(
               uniqueId: entry.uniqueId,
               name: entry.name,
               packageName: entry.packageName,
+              resourceType: entry.resourceType,
+              ...(entry.testType ? { testType: entry.testType } : {}),
               dependsOnNodeIds: [...entry.dependsOnNodeIds].sort(),
               targetNodeIds: [...entry.targetNodeIds].sort(),
               ...(entry.originalFilePath

--- a/packages/governance/adapter-dbt/src/normalize-dbt-artifacts.spec.ts
+++ b/packages/governance/adapter-dbt/src/normalize-dbt-artifacts.spec.ts
@@ -283,6 +283,9 @@ describe('dbt artifact normalization', () => {
             meta: {
               severity: 'error',
             },
+            test_metadata: {
+              name: 'relationships',
+            },
             depends_on: {
               nodes: [
                 'model.valid_project.orders',
@@ -336,6 +339,8 @@ describe('dbt artifact normalization', () => {
             uniqueId: 'test.valid_project.relationships_orders_country_code',
             name: 'relationships_orders_country_code',
             packageName: 'valid_project',
+            resourceType: 'test',
+            testType: 'relationships',
             dependsOnNodeIds: [
               'model.valid_project.orders',
               'seed.valid_project.countries',
@@ -368,6 +373,25 @@ describe('dbt artifact normalization', () => {
         }),
       ]),
     );
+    expect(normalized.relations).toHaveLength(2);
+    expect(
+      normalized.relations?.some(
+        (relation) => relation.kind === 'traceability',
+      ),
+    ).toBe(false);
+    expect(
+      normalized.relations?.some((relation) =>
+        relation.id?.startsWith('dbt:tests:'),
+      ),
+    ).toBe(false);
+    expect(
+      normalized.relations?.some((relation) => {
+        const expansion = relation.extensions?.['governance-extension:dbt'] as
+          | DbtRelationExpansionEnvelope
+          | undefined;
+        return expansion?.data.relationKind === 'tests';
+      }),
+    ).toBe(false);
   });
 
   it('preserves stable dbt identifiers and metadata on canonical nodes', () => {
@@ -703,6 +727,23 @@ describe('dbt artifact normalization', () => {
         }),
       ]),
     );
+    expect(normalized.relations).toHaveLength(6);
+    expect(
+      normalized.relations?.every((relation) => relation.kind === 'dependency'),
+    ).toBe(true);
+    expect(
+      normalized.relations?.every(
+        (relation) => !relation.id?.startsWith('dbt:tests:'),
+      ),
+    ).toBe(true);
+    expect(
+      normalized.relations?.every((relation) => {
+        const expansion = relation.extensions?.['governance-extension:dbt'] as
+          | DbtRelationExpansionEnvelope
+          | undefined;
+        return expansion?.data.relationKind !== 'tests';
+      }),
+    ).toBe(true);
   });
 
   it.each([

--- a/packages/governance/adapter-dbt/src/normalize-dbt-artifacts.ts
+++ b/packages/governance/adapter-dbt/src/normalize-dbt-artifacts.ts
@@ -82,6 +82,8 @@ interface RelationMappingResult {
   unsupportedCount: number;
 }
 
+type CanonicalDbtRelationKind = 'lineage' | 'exposes';
+
 interface DbtSourceMetadataView {
   tableMeta: ResourceRecord;
   sourceMeta?: ResourceRecord;
@@ -231,6 +233,10 @@ function mapDbtRelations(
       continue;
     }
 
+    if (isDbtTestEvidenceResourceType(sourceResource.resourceType)) {
+      continue;
+    }
+
     const dependsOn = readDependsOnNodeIds(
       sourceResource.manifestRecord,
       sourceUniqueId,
@@ -259,6 +265,18 @@ function mapDbtRelations(
         continue;
       }
 
+      const targetResourceType = readManifestResourceType(
+        targetManifestResource,
+      );
+      if (
+        isDbtTestEvidenceRelation(
+          sourceResource.resourceType,
+          targetResourceType,
+        )
+      ) {
+        continue;
+      }
+
       const targetResource = normalizedResourcesById.get(targetUniqueId);
       if (!targetResource) {
         diagnostics.push(
@@ -272,10 +290,7 @@ function mapDbtRelations(
       }
 
       relationKeys.add(relationKey);
-      const relationKind = buildDbtRelationKind(
-        sourceResource.resourceType,
-        targetResource.resourceType,
-      );
+      const relationKind = buildDbtRelationKind(sourceResource.resourceType);
       const relationMetadata = buildRelationMetadata(
         sourceUniqueId,
         sourceResource.manifestRecord,
@@ -315,7 +330,7 @@ function buildRelationMetadata(
   sourceResource: ResourceRecord,
   targetUniqueId: string,
   targetResource: ResourceRecord,
-  relationKind: GovernanceRelationInput['kind'],
+  relationKind: CanonicalDbtRelationKind,
 ): Record<string, unknown> {
   const targetResourceType = readOptionalString(targetResource.resource_type);
   const dependencyKind = targetResourceType === 'source' ? 'source' : 'ref';
@@ -641,11 +656,14 @@ function normalizeDbtTestEvidence(
     : undefined;
   const tags = readStringArray(record.tags);
   const meta = asRecord(record.meta);
+  const testType = readDbtTestType(record);
 
   return {
     uniqueId,
     name,
     packageName,
+    resourceType: 'test',
+    ...(testType ? { testType } : {}),
     dependsOnNodeIds: [...dependsOn.nodeIds].sort(),
     targetNodeIds: [...dependsOn.nodeIds].sort(),
     ...(originalFilePath ? { originalFilePath } : {}),
@@ -1054,29 +1072,24 @@ function toCanonicalNodeKind(
 
 function buildDbtRelationKind(
   sourceResourceType: string,
-  targetResourceType: string,
-): 'lineage' | 'exposes' | 'tests' {
+): CanonicalDbtRelationKind {
   if (sourceResourceType === 'exposure') {
     return 'exposes';
-  }
-
-  if (sourceResourceType === 'test' || targetResourceType === 'test') {
-    return 'tests';
   }
 
   return 'lineage';
 }
 
 function toCanonicalRelationKind(
-  relationKind: 'lineage' | 'exposes' | 'tests',
+  _relationKind: CanonicalDbtRelationKind,
 ): GovernanceRelationInput['kind'] {
-  return relationKind === 'tests' ? 'traceability' : 'dependency';
+  return 'dependency';
 }
 
 function buildDbtRelationId(
   sourceNodeId: string,
   targetNodeId: string,
-  relationKind: GovernanceRelationInput['kind'],
+  relationKind: CanonicalDbtRelationKind,
 ): string {
   return `dbt:${relationKind}:${sourceNodeId}->${targetNodeId}`;
 }
@@ -1086,8 +1099,29 @@ function readManifestResourceType(resource: DbtManifestResource): string {
   return readOptionalString(record?.resource_type) ?? 'unknown';
 }
 
+function readDbtTestType(resource: ResourceRecord): string | undefined {
+  const testMetadata = asRecord(resource.test_metadata);
+  return (
+    readOptionalString(testMetadata?.name) ?? readOptionalString(resource.type)
+  );
+}
+
 function isCanonicalDbtAssetResourceType(resourceType: string): boolean {
   return resourceType !== 'test' && isSupportedResourceType(resourceType);
+}
+
+function isDbtTestEvidenceResourceType(resourceType: string): boolean {
+  return resourceType === 'test';
+}
+
+function isDbtTestEvidenceRelation(
+  sourceResourceType: string,
+  targetResourceType: string,
+): boolean {
+  return (
+    isDbtTestEvidenceResourceType(sourceResourceType) ||
+    isDbtTestEvidenceResourceType(targetResourceType)
+  );
 }
 
 function isSupportedResourceType(resourceType: string): boolean {

--- a/packages/governance/extension-dbt/src/contracts.ts
+++ b/packages/governance/extension-dbt/src/contracts.ts
@@ -69,6 +69,8 @@ export interface DbtGovernanceWorkspaceTestEvidence {
   uniqueId: string;
   name: string;
   packageName: string;
+  resourceType: 'test';
+  testType?: string;
   dependsOnNodeIds: string[];
   targetNodeIds: string[];
   originalFilePath?: string;

--- a/packages/governance/extension-dbt/src/dbt-graph.ts
+++ b/packages/governance/extension-dbt/src/dbt-graph.ts
@@ -346,6 +346,7 @@ function isDbtWorkspaceTestEvidence(
     typeof value.uniqueId === 'string' &&
     typeof value.name === 'string' &&
     typeof value.packageName === 'string' &&
+    value.resourceType === 'test' &&
     Array.isArray(value.targetNodeIds) &&
     value.targetNodeIds.every((entry) => typeof entry === 'string')
   );

--- a/packages/governance/extension-dbt/src/metrics.spec.ts
+++ b/packages/governance/extension-dbt/src/metrics.spec.ts
@@ -411,6 +411,69 @@ describe('dbt governance metrics', () => {
     });
   });
 
+  it('counts workspace dbt test evidence for coverage metrics without canonical test relations', () => {
+    const modelId = 'model.analytics.orders';
+    const workspace: GovernanceWorkspace = {
+      ...createWorkspace([
+        createProject({
+          id: modelId,
+          layer: 'marts',
+          domain: 'finance',
+          owner: 'finance-platform',
+          description: true,
+          tests: false,
+          contract: true,
+        }),
+        createProject({
+          id: 'model.analytics.customers',
+          layer: 'marts',
+          domain: 'finance',
+          owner: 'finance-platform',
+          description: true,
+          tests: false,
+          contract: true,
+        }),
+      ]),
+      extensions: {
+        'governance-extension:dbt': {
+          extensionId: 'governance-extension:dbt',
+          contractVersion: '1',
+          data: {
+            kind: 'workspace',
+            technology: 'dbt',
+            projectName: 'analytics',
+            testEvidence: [
+              {
+                uniqueId: 'test.analytics.not_null_orders_order_id',
+                name: 'not_null_orders_order_id',
+                packageName: 'analytics',
+                resourceType: 'test',
+                testType: 'not_null',
+                dependsOnNodeIds: [modelId],
+                targetNodeIds: [modelId],
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const byId = new Map(
+      buildDbtGovernanceMetrics(createMetricInput(workspace)).map(
+        (measurement) => [measurement.id, measurement],
+      ),
+    );
+
+    expect(byId.get('dbt-test-coverage-ratio')).toMatchObject({
+      value: 0.5,
+      metadata: {
+        numerator: 1,
+        denominator: 2,
+        countedNodeIds: ['model.analytics.orders'],
+      },
+    });
+  });
+
   it('uses explicit zero-denominator handling for ratio metrics when no dbt models are eligible', () => {
     const workspace = createWorkspace([
       createProject({

--- a/packages/governance/extension-dbt/src/signals.spec.ts
+++ b/packages/governance/extension-dbt/src/signals.spec.ts
@@ -513,6 +513,8 @@ describe('dbt governance signals', () => {
                 uniqueId: 'test.analytics.not_null_orders_order_id',
                 name: 'not_null_orders_order_id',
                 packageName: 'analytics',
+                resourceType: 'test',
+                testType: 'not_null',
                 dependsOnNodeIds: [modelId],
                 targetNodeIds: [modelId],
               },


### PR DESCRIPTION
closes #486